### PR TITLE
Add support for querying the events-log plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,14 @@ This library might be working with older versions as well.
 If you notice an incompatibility [open a new issue](https://github.com/andygrunwald/go-gerrit/issues/new) or try to fix it.
 We welcome contribution!
 
+
+### What about adding code to support the REST API of an optional plugin?
+
+It will depend on the plugin, you are welcome to [open a new issue](https://github.com/andygrunwald/go-gerrit/issues/new) first to propose the idea if you wish.
+As an example the addition of support for events-log plugin was supported because the plugin itself is fairly
+popular and the structures that the REST API uses could also be used by `gerrit stream-events`.
+
+
 ## License
 
 This project is released under the terms of the [MIT license](http://en.wikipedia.org/wiki/MIT_License).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ go-gerrit is a [Go(lang)](https://golang.org/) client library for accessing the 
 	* [/groups/](https://godoc.org/github.com/andygrunwald/go-gerrit#GroupsService)
 	* [/plugins/](https://godoc.org/github.com/andygrunwald/go-gerrit#PluginsService)
 	* [/projects/](https://godoc.org/github.com/andygrunwald/go-gerrit#ProjectsService)
+* Supports optional plugin APIs such as
+	* events-log - [About](https://gerrit.googlesource.com/plugins/events-log/+/master/src/main/resources/Documentation/about.md), [REST API](https://gerrit.googlesource.com/plugins/events-log/+/master/src/main/resources/Documentation/rest-api-events.md)
+
 
 ## Installation
 

--- a/events.go
+++ b/events.go
@@ -78,12 +78,12 @@ type EventsLogOptions struct {
 // getURL returns the url that should be used in the request.  This will vary
 // depending on the options provided to GetEvents.
 func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error) {
-	url, err := url.Parse("/plugins/events-log/events/")
+	parsed, err := url.Parse("/plugins/events-log/events/")
 	if err != nil {
 		return "", err
 	}
 
-	query := url.Query()
+	query := parsed.Query()
 
 	if !options.From.IsZero() {
 		query.Set("t1", options.From.Format("2006-01-02 15:04:05"))
@@ -93,7 +93,7 @@ func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error
 		query.Set("t2", options.To.Format("2006-01-02 15:04:05"))
 	}
 
-	return url.String(), nil
+	return parsed.String(), nil
 }
 
 // GetEvents returns a list of events for the given input options.  Use of this

--- a/events.go
+++ b/events.go
@@ -78,13 +78,12 @@ type EventsLogOptions struct {
 // getURL returns the url that should be used in the request.  This will vary
 // depending on the options provided to GetEvents.
 func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error) {
-	parsedUrl, err := url.Parse("/plugins/events-log/events/")
-
+	url, err := url.Parse("/plugins/events-log/events/")
 	if err != nil {
 		return "", err
 	}
 
-	query := parsedUrl.Query()
+	query := url.Query()
 
 	if options.From != nil {
 		query.Set("t1", options.From.Format("2006-01-02 15:04:05"))
@@ -94,7 +93,7 @@ func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error
 		query.Set("t2", options.To.Format("2006-01-02 15:04:05"))
 	}
 
-	return parsedUrl.String(), nil
+	return url.String(), nil
 }
 
 // GetEvents returns a list of events for the given input options.  Use of this

--- a/events.go
+++ b/events.go
@@ -68,11 +68,11 @@ type EventsLogService struct {
 	client *Client
 }
 
-// EventLogService contains options for querying events from the events-logs
+// EventsLogOptions contains options for querying events from the events-logs
 // plugin.
 type EventsLogOptions struct {
-	From *time.Time
-	To   *time.Time
+	From time.Time
+	To   time.Time
 }
 
 // getURL returns the url that should be used in the request.  This will vary
@@ -85,11 +85,12 @@ func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error
 
 	query := url.Query()
 
-	if options.From != nil {
+
+	if !options.From.IsZero() {
 		query.Set("t1", options.From.Format("2006-01-02 15:04:05"))
 	}
 
-	if options.To != nil {
+	if !options.To.IsZero() {
 		query.Set("t2", options.To.Format("2006-01-02 15:04:05"))
 	}
 

--- a/events.go
+++ b/events.go
@@ -1,0 +1,124 @@
+package gerrit
+
+import (
+	"time"
+	"net/url"
+	log "github.com/sirupsen/logrus"
+)
+
+// PatchSet contains detailed information about a specific patch set.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/json.html#patchSet
+type PatchSet struct {
+	Number    string      `json:"number"`
+	Revision  string      `json:"revision"`
+	Parents   []string    `json:"parents"`
+	Ref       string      `json:"ref"`
+	Uploader  AccountInfo `json:"uploader"`
+	Author    AccountInfo `json:"author"`
+	CreatedOn int         `json:"createdOn"`
+	IsDraft   bool        `json:"isDraft"`
+	Kind      string      `json:"kind"`
+}
+
+// RefUpdate contains data about a reference update.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/json.html#refUpdate
+type RefUpdate struct {
+	OldRev  string `json:"oldRev"`
+	NewRev  string `json:"newRev"`
+	RefName string `json:"refName"`
+	Project string `json:"project"`
+}
+
+// EventInfo contains information about an event emitted by Gerrit.  This
+// structure can be used either when parsing streamed events or when reading
+// the output of the events-log plugin.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/cmd-stream-events.html#events
+type EventInfo struct {
+	Type           string        `json:"type"`
+	Change         ChangeInfo    `json:"change,omitempty"`
+	PatchSet       PatchSet      `json:"patchSet,omitempty"`
+	EventCreatedOn int           `json:"eventCreatedOn,omitempty"`
+	Reason         string        `json:"reason,omitempty"`
+	Abandoner      AccountInfo   `json:"abandoner,omitempty"`
+	Restorer       AccountInfo   `json:"restorer,omitempty"`
+	Submitter      AccountInfo   `json:"submitter,omitempty"`
+	Author         AccountInfo   `json:"author,omitempty"`
+	Uploader       AccountInfo   `json:"uploader,omitempty"`
+	Approvals      []AccountInfo `json:"approvals,omitempty"`
+	Comment        string        `json:"comment,omitempty"`
+	Editor         AccountInfo   `json:"editor,omitempty"`
+	Added          []string      `json:"added,omitempty"`
+	Removed        []string      `json:"removed,omitempty"`
+	Hashtags       []string      `json:"hashtags,omitempty"`
+	RefUpdate      RefUpdate     `json:"refUpdate,omitempty"`
+	Project        string        `json:"project,omitempty"`
+	Reviewer       AccountInfo   `json:"reviewer,omitempty"`
+	OldTopic       string        `json:"oldTopic,omitempty"`
+	Changer        AccountInfo   `json:"changer,omitempty"`
+}
+
+// EventLogService contains functions for querying the API provided
+// by the optional events-log plugin.
+type EventsLogService struct {
+	client *Client
+}
+
+// EventLogService contains options for querying events from the events-logs
+// plugin.
+type EventsLogOptions struct {
+	From *time.Time
+	To   *time.Time
+}
+
+// getURL returns the url that should be used in the request.  This will vary
+// depending on the options provided to GetEvents.
+func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error) {
+	parsedUrl, err := url.Parse("/plugins/events-log/events/")
+
+	if err != nil {
+		return "", err
+	}
+
+	query := parsedUrl.Query()
+
+	if options.From != nil {
+		query.Set("t1", options.From.Format("2006-01-02 15:04:05"))
+	}
+
+	if options.To != nil {
+		query.Set("t2", options.To.Format("2006-01-02 15:04:05"))
+	}
+
+	return parsedUrl.String(), nil
+}
+
+// GetEvents returns a list of events for the given input options.  Use of this
+// function an authenticated user.
+//
+// Gerrit API docs: https://<yourserver>/plugins/events-log/Documentation/rest-api-events.html
+func (events *EventsLogService) GetEvents(options *EventsLogOptions) (*[]EventInfo, *Response, error) {
+	url, err := events.getURL(options)
+	log.Info(url)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	request, err := events.client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var eventInfo *[]EventInfo
+
+	response, err := events.client.Do(request, eventInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return eventInfo, response, err
+
+}

--- a/events.go
+++ b/events.go
@@ -62,7 +62,7 @@ type EventInfo struct {
 	Changer        AccountInfo   `json:"changer,omitempty"`
 }
 
-// EventLogService contains functions for querying the API provided
+// EventsLogService contains functions for querying the API provided
 // by the optional events-log plugin.
 type EventsLogService struct {
 	client *Client
@@ -84,7 +84,6 @@ func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error
 	}
 
 	query := url.Query()
-
 
 	if !options.From.IsZero() {
 		query.Set("t1", options.From.Format("2006-01-02 15:04:05"))

--- a/events.go
+++ b/events.go
@@ -101,12 +101,12 @@ func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error
 //
 // Gerrit API docs: https://<yourserver>/plugins/events-log/Documentation/rest-api-events.html
 func (events *EventsLogService) GetEvents(options *EventsLogOptions) (*[]EventInfo, *Response, error) {
-	url, err := events.getURL(options)
+	requestURL, err := events.getURL(options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	request, err := events.client.NewRequest("GET", url, nil)
+	request, err := events.client.NewRequest("GET", requestURL, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/events.go
+++ b/events.go
@@ -93,6 +93,11 @@ func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error
 		query.Set("t2", options.To.Format("2006-01-02 15:04:05"))
 	}
 
+	encoded := query.Encode()
+	if len(encoded) > 0 {
+		parsed.RawQuery = encoded
+	}
+
 	return parsed.String(), nil
 }
 

--- a/events_test.go
+++ b/events_test.go
@@ -1,0 +1,135 @@
+package gerrit_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/andygrunwald/go-gerrit"
+)
+
+var (
+	fakeEvents = []byte(`
+	{"submitter":{"name":"Foo Bar","email":"fbar@example.com","username":"fbar"},"newRev":"0000000000000000000000000000000000000000","patchSet":{"number":"1","revision":"0000000000000000000000000000000000000000","parents":["0000000000000000000000000000000000000000"],"ref":"refs/changes/1/1/1","uploader":{"name":"Foo Bar","email":"fbar@example.com","username":"fbar"},"createdOn":1470000000,"author":{"name":"Foo Bar","email":"fbar@example.com","username":"fbar"},"isDraft":false,"kind":"TRIVIAL_REBASE","sizeInsertions":10,"sizeDeletions":0},"change":{"project":"test","branch":"master","id":"Iffffffffffffffffffffffffffffffffffffffff","number":"1","subject":"subject","owner":{"name":"Foo Bar","email":"fbar@example.com","username":"fbar"},"url":"https://localhost/1","commitMessage":"commitMessage\n\nline2\n\nChange-Id: Iffffffffffffffffffffffffffffffffffffffff\n","status":"MERGED"},"type":"change-merged","eventCreatedOn":1470000000}
+	{"author":{"name":"Foo Bar","email":"fbar@example.com","username":"fbar"},"comment":"Patch Set 1:\n\n(2 comments)\n\nSome comment","patchSet":{"number":"1","revision":"0000000000000000000000000000000000000000","parents":["0000000000000000000000000000000000000000"],"ref":"refs/changes/1/1/1","uploader":{"name":"Foo Bar","email":"fbar@example.com","username":"fbar"},"createdOn":1470000000,"author":{"name":"Foo Bar","email":"fbar@example.com","username":"fbar"},"isDraft":false,"kind":"REWORK","sizeInsertions":4,"sizeDeletions":-2},"change":{"project":"test","branch":"master","id":"Iffffffffffffffffffffffffffffffffffffffff","number":"1","subject":"subject","owner":{"name":"Foo Bar","email":"fbar@example.com","username":"fbar"},"url":"https://localhost/1","commitMessage":"commitMessage\n\nChange-Id: Iffffffffffffffffffffffffffffffffffffffff\n","status":"NEW"},"type":"comment-added","eventCreatedOn":1470000000}`)
+)
+
+func TestEventsLogService_GetEvents_NoDateRange(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/plugins/events-log/events/", func(writer http.ResponseWriter, request *http.Request) {
+		writer.Write(fakeEvents)
+	})
+
+	options := &gerrit.EventsLogOptions{}
+	events, _, err := testClient.EventsLog.GetEvents(options)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(*events) != 2 {
+		t.Error("Expected 2 events")
+	}
+
+	// Basic test
+	for i, event := range *events {
+		switch i {
+		case 0:
+			if event.Type != "change-merged" {
+				t.Error("Expected event type to be `change-merged`")
+			}
+		case 1:
+			if event.Type != "comment-added" {
+				t.Error("Expected event type to be `comment-added`")
+			}
+		}
+	}
+}
+
+func TestEventsLogService_GetEvents_DateRangeFromAndTo(t *testing.T) {
+	setup()
+	defer teardown()
+
+	to := time.Now()
+	from := to.AddDate(0, 0, -7)
+
+	testMux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		query := request.URL.Query()
+
+		fromFormat := from.Format("2006-01-02 15:04:05")
+		if query.Get("t1") != fromFormat {
+			t.Errorf("%s != %s", query.Get("t1"), fromFormat)
+		}
+
+		toFormat := to.Format("2006-01-02 15:04:05")
+		if query.Get("t2") != toFormat {
+			t.Errorf("%s != %s", query.Get("t2"), toFormat)
+		}
+
+		writer.Write(fakeEvents)
+	})
+
+	options := &gerrit.EventsLogOptions{From: from, To: to}
+	_, _, err := testClient.EventsLog.GetEvents(options)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestEventsLogService_GetEvents_DateRangeFromOnly(t *testing.T) {
+	setup()
+	defer teardown()
+
+	to := time.Now()
+	from := to.AddDate(0, 0, -7)
+
+	testMux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		query := request.URL.Query()
+
+		fromFormat := from.Format("2006-01-02 15:04:05")
+		if query.Get("t1") != fromFormat {
+			t.Errorf("%s != %s", query.Get("t1"), fromFormat)
+		}
+
+		if query.Get("t2") != "" {
+			t.Error("Did not expect t2 to be set")
+		}
+
+		writer.Write(fakeEvents)
+	})
+
+	options := &gerrit.EventsLogOptions{From: from}
+	_, _, err := testClient.EventsLog.GetEvents(options)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestEventsLogService_GetEvents_DateRangeToOnly(t *testing.T) {
+	setup()
+	defer teardown()
+
+	to := time.Now()
+
+	testMux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		query := request.URL.Query()
+
+		toFormat := to.Format("2006-01-02 15:04:05")
+		if query.Get("t2") != toFormat {
+			t.Errorf("%s != %s", query.Get("t2"), toFormat)
+		}
+
+		if query.Get("t1") != "" {
+			t.Error("Did not expect t1 to be set")
+		}
+
+		writer.Write(fakeEvents)
+	})
+
+	options := &gerrit.EventsLogOptions{To: to}
+	_, _, err := testClient.EventsLog.GetEvents(options)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/gerrit.go
+++ b/gerrit.go
@@ -271,18 +271,22 @@ func (c *Client) DeleteRequest(urlStr string, body interface{}) (*Response, erro
 	return c.Do(req, nil)
 }
 
-// RemoveMagicPrefixLine removed the "magic prefix line" of Gerris JSON response.
-// the JSON response body starts with a magic prefix line that must be stripped before feeding the rest of the response body to a JSON parser.
-// The reason for this is to prevent against Cross Site Script Inclusion (XSSI) attacks.
+// RemoveMagicPrefixLine removes the "magic prefix line" of Gerris JSON
+// response if present. The JSON response body starts with a magic prefix line
+// that must be stripped before feeding the rest of the response body to a JSON
+// parser. The reason for this is to prevent against Cross Site Script
+// Inclusion (XSSI) attacks.  By default all standard Gerrit APIs include this
+// prefix line though some plugins may not.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api.html#output
 func RemoveMagicPrefixLine(body []byte) []byte {
-	index := bytes.IndexByte(body, '\n')
-	if index > -1 {
-		// +1 to catch the \n as well
-		body = body[(index + 1):]
+	if bytes.HasPrefix(body, []byte(")]}'\n")) {
+		index := bytes.IndexByte(body, '\n')
+		if index > -1 {
+			// +1 to catch the \n as well
+			body = body[(index + 1):]
+		}
 	}
-
 	return body
 }
 

--- a/gerrit.go
+++ b/gerrit.go
@@ -30,7 +30,8 @@ type Client struct {
 	// Gerrit service for authentication
 	Authentication *AuthenticationService
 
-	// Services used for talking to different parts of the Gerrit API.
+	// Services used for talking to different parts of the standard
+	// Gerrit API.
 	Access   *AccessService
 	Accounts *AccountsService
 	Changes  *ChangesService
@@ -38,6 +39,10 @@ type Client struct {
 	Groups   *GroupsService
 	Plugins  *PluginsService
 	Projects *ProjectsService
+
+	// Additional services used for talking to non-standard Gerrit
+	// APIs.
+	EventsLog *EventsLogService
 }
 
 // Response is a Gerrit API response.
@@ -74,6 +79,7 @@ func NewClient(gerritURL string, httpClient *http.Client) (*Client, error) {
 	c.Groups = &GroupsService{client: c}
 	c.Plugins = &PluginsService{client: c}
 	c.Projects = &ProjectsService{client: c}
+	c.EventsLog = &EventsLogService{client: c}
 
 	return c, nil
 }

--- a/gerrit_test.go
+++ b/gerrit_test.go
@@ -293,3 +293,18 @@ func TestRemoveMagicPrefixLine(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveMagicPrefixLineDoesNothingWithoutPrefix(t *testing.T) {
+	mockData := []struct {
+		Current, Expected []byte
+	}{
+		{[]byte(`{"A":"a"}`), []byte(`{"A":"a"}`)},
+		{[]byte(`{"A":"a"}`), []byte(`{"A":"a"}`)},
+	}
+	for _, mock := range mockData {
+		body := gerrit.RemoveMagicPrefixLine(mock.Current)
+		if !reflect.DeepEqual(body, mock.Expected) {
+			t.Errorf("Response body = %v, want %v", body, mock.Expected)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for querying information about Gerrit events via the optional events-log plugin.  The structures this PR adds could also be used when parsing output from the built-in `gerrit stream-events` command over ssh. 