### PR TITLE
A2 hash should use the request's method (closes #13)

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -51,7 +51,7 @@ func (s *AuthenticationService) SetDigestAuth(username, password string) {
 // returns 401 Unauthorized and authType was set to authTypeDigest. The
 // resulting string is used to set the Authorization header before retrying
 // the request.
-func (s *AuthenticationService) digestAuthHeader(response *http.Response) (string, error) {
+func (s *AuthenticationService) digestAuthHeader(method string, response *http.Response) (string, error) {
 	authenticateHeader := response.Header.Get("WWW-Authenticate")
 	if authenticateHeader == "" {
 		return "", fmt.Errorf("WWW-Authenticate header is missing")
@@ -112,7 +112,7 @@ func (s *AuthenticationService) digestAuthHeader(response *http.Response) (strin
 
 	// A2
 	h = md5.New()
-	A2 := fmt.Sprintf("GET:%s", uriHeader)
+	A2 := fmt.Sprintf("%s:%s", method, uriHeader)
 	io.WriteString(h, A2)
 	HA2 := fmt.Sprintf("%x", h.Sum(nil))
 

--- a/authentication.go
+++ b/authentication.go
@@ -51,7 +51,7 @@ func (s *AuthenticationService) SetDigestAuth(username, password string) {
 // returns 401 Unauthorized and authType was set to authTypeDigest. The
 // resulting string is used to set the Authorization header before retrying
 // the request.
-func (s *AuthenticationService) digestAuthHeader(method string, response *http.Response) (string, error) {
+func (s *AuthenticationService) digestAuthHeader(response *http.Response) (string, error) {
 	authenticateHeader := response.Header.Get("WWW-Authenticate")
 	if authenticateHeader == "" {
 		return "", fmt.Errorf("WWW-Authenticate header is missing")
@@ -112,7 +112,7 @@ func (s *AuthenticationService) digestAuthHeader(method string, response *http.R
 
 	// A2
 	h = md5.New()
-	A2 := fmt.Sprintf("%s:%s", method, uriHeader)
+	A2 := fmt.Sprintf("%s:%s", response.Request.Method, uriHeader)
 	io.WriteString(h, A2)
 	HA2 := fmt.Sprintf("%x", h.Sum(nil))
 

--- a/gerrit.go
+++ b/gerrit.go
@@ -277,7 +277,7 @@ func (c *Client) addAuthentication(req *http.Request) error {
 		defer response.Body.Close()
 
 		if response.StatusCode == http.StatusUnauthorized {
-			authorization, err := c.Authentication.digestAuthHeader(req.Method, response)
+			authorization, err := c.Authentication.digestAuthHeader(response)
 
 			if err != nil {
 				return err

--- a/gerrit.go
+++ b/gerrit.go
@@ -277,7 +277,7 @@ func (c *Client) addAuthentication(req *http.Request) error {
 		defer response.Body.Close()
 
 		if response.StatusCode == http.StatusUnauthorized {
-			authorization, err := c.Authentication.digestAuthHeader(response)
+			authorization, err := c.Authentication.digestAuthHeader(req.Method, response)
 
 			if err != nil {
 				return err


### PR DESCRIPTION
According to RFC2617 3.2.2.3 A2, 'If the "qop" directive's
value is "auth" or is unspecified, then A2 is':
```
  A2       = Method ":" digest-uri-value
```
Before this commit 'Method' was always GET even if
the request was a POST, PUT, etc.

For some reason, this bug has only posed a problem
for SetReview.  In other cases Gerrit seems to accept
the request rather than returning 401 Unauthorized.