### PR TITLE
Use http.StatusConflict instead of hard coded value in SubmitChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ first. For more complete details see
 
 ### 0.1.1 (not yet released)
 
+* Minor fix to SubmitChange to use the `http.StatusConflict` constant
+  instead of a hard coded value when comparing response codes.
 
 ### 0.1.0
 

--- a/changes.go
+++ b/changes.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 )
 
 // ChangesService contains Change related REST endpoints
@@ -687,7 +688,7 @@ func (s *ChangesService) SubmitChange(changeID string, input *SubmitInput) (*Cha
 	v := new(ChangeInfo)
 
 	resp, err := s.client.Do(req, v)
-	if 409 == resp.StatusCode {
+	if resp.StatusCode == http.StatusConflict {
 		body, _ := ioutil.ReadAll(resp.Body)
 		err = errors.New(string(body[:]))
 	}


### PR DESCRIPTION
The use of `http.StatusConflict` does not change how the code functions, it just makes it easier to read.