### PR TITLE
Query url parameters should not escape + or :

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ first. For more complete details see
   instead of a hard coded value when comparing response codes.
 * Updated AccountInfo.AccountID to be omitted of empty (such as when 
   used in ApprovalInfo).
+* + and : in url parameters for queries are no longer escaped. This was
+  causing `400 Bad Request` to be returned when the + symbol was
+  included as part of the query. To match behavior with Gerrit's search
+  handling, the : symbol was also excluded.
 
 ### 0.1.0
 

--- a/changes_test.go
+++ b/changes_test.go
@@ -31,3 +31,30 @@ func ExampleChangesService_QueryChanges() {
 	// Output:
 	// Project: platform/art -> ART: Change return types of field access entrypoints -> https://android-review.googlesource.com/249244
 }
+
+// Prior to fixing #18 this test would fail.
+func ExampleChangesService_QueryChangesWithSymbols() {
+	instance := "https://android-review.googlesource.com/"
+	client, err := gerrit.NewClient(instance, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	opt := &gerrit.QueryChangeOptions{}
+	opt.Query = []string{
+		"change:249244+status:merged",
+	}
+	opt.Limit = 2
+	opt.AdditionalFields = []string{"LABELS"}
+	changes, _, err := client.Changes.QueryChanges(opt)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, change := range *changes {
+		fmt.Printf("Project: %s -> %s -> %s%d\n", change.Project, change.Subject, instance, change.Number)
+	}
+
+	// Output:
+	// Project: platform/art -> ART: Change return types of field access entrypoints -> https://android-review.googlesource.com/249244
+}


### PR DESCRIPTION
See #18 for details.
