### PR TITLE
Update NewClient handle credentials in the url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ first. For more complete details see
 * Updated internal function digestAuthHeader to return exported errors
   (ErrWWWAuthenticateHeader*) rather than calling fmt.Errorf. This makes
   it easier to test against externally and also fixes a lint issue too.
+* Added NewClientFromURL function which allows a single url to 
+  define the host to connect to as well as the credentials to use.
 
 ### 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ first. For more complete details see
 * Updated internal function digestAuthHeader to return exported errors
   (ErrWWWAuthenticateHeader*) rather than calling fmt.Errorf. This makes
   it easier to test against externally and also fixes a lint issue too.
-* Added NewClientFromURL function which allows a single url to 
-  define the host to connect to as well as the credentials to use.
+* Updated NewClient function to handle credentials in the url.
 
 ### 0.1.0
 

--- a/gerrit.go
+++ b/gerrit.go
@@ -172,7 +172,10 @@ func NewClientFromURL(httpURL string, httpClient *http.Client) (*Client, error) 
 		return client, err
 	}
 
-	return nil, ErrAuthenticationFailed
+	// Reset auth in case the consumer needs to do something special.
+	client.Authentication.ResetAuth()
+
+	return client, ErrAuthenticationFailed
 }
 
 // NewRequest creates an API request.

--- a/gerrit.go
+++ b/gerrit.go
@@ -56,6 +56,15 @@ var (
 	// ErrNoInstanceGiven is returned by NewClient in the event the
 	// gerritURL argument was blank.
 	ErrNoInstanceGiven = errors.New("No Gerrit instance given.")
+
+	// ErrUserProvidedWithoutPassword is returned by NewClientFromURL
+	// if a user name is provided without a password.
+	ErrUserProvidedWithoutPassword = errors.New("A username was provided without a password.")
+
+	// ErrAuthenticationFailed is returned by NewClientFromURL in the event the provided
+	// credentials didn't allow us to query account information using digest, basic or cookie
+	// auth.
+	ErrAuthenticationFailed = errors.New("Failed to authenticate using the provided credentials.")
 )
 
 // NewClient returns a new Gerrit API client. The gerritURL argument has to be the
@@ -90,6 +99,70 @@ func NewClient(endpoint string, httpClient *http.Client) (*Client, error) {
 	c.EventsLog = &EventsLogService{client: c}
 
 	return c, nil
+}
+
+// NewClientFromURL is a wrapper for NewClient with two notable differences:
+//   * The url may contain credentials, http://admin:secret@localhost:8081/ for
+//     example. These credentials may either be a user name and password or
+//     name and value as in the case of cookie based authentication.
+//   * If the url contains credentials then this function will attempt to validate
+//     the credentials before returning the client. An error will be returned if the
+//     credentials cannot be validated.
+// The process of validating the credentials is relatively simple and only requires that
+// the provided user have permission to GET /a/accounts/self. Internally NewClientFromURL
+// calls each of the Set*Auth functions followed by GetAccount("self"). The first call to
+// GetAccount("self") which succeeds will return a *Client.
+func NewClientFromURL(httpURL string, httpClient *http.Client) (*Client, error) {
+	baseURL, err := url.Parse(httpURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Neither username or password were provided so fall back
+	// on the original behavior.
+	if baseURL.User == nil {
+		return NewClient(httpURL, httpClient)
+	}
+
+	username := baseURL.User.Username()
+	password, haspassword := baseURL.User.Password()
+
+	// Catches cases like http://user@localhost:8081/ where no password
+	// was at all. If a blank password is required
+	if !haspassword {
+		return nil, ErrUserProvidedWithoutPassword
+	}
+
+	// Reconstruct the url but without the username and password.
+	parsedURL := fmt.Sprintf(
+		"%s://%s%s", baseURL.Scheme, baseURL.Host, baseURL.RequestURI())
+	client, err := NewClient(parsedURL, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	// Digest auth (first since that's the default auth type)
+	client.Authentication.SetDigestAuth(username, password)
+	_, response, err := client.Accounts.GetAccount("self")
+	if err == nil && response.StatusCode == http.StatusOK {
+		return client, nil
+	}
+
+	// Basic auth
+	client.Authentication.SetBasicAuth(username, password)
+	_, response, err = client.Accounts.GetAccount("self")
+	if err == nil && response.StatusCode == http.StatusOK {
+		return client, nil
+	}
+
+	// Cookie auth
+	client.Authentication.SetCookieAuth(username, password)
+	_, response, err = client.Accounts.GetAccount("self")
+	if err == nil && response.StatusCode == http.StatusOK {
+		return client, nil
+	}
+
+	return nil, ErrAuthenticationFailed
 }
 
 // NewRequest creates an API request.

--- a/gerrit_test.go
+++ b/gerrit_test.go
@@ -116,6 +116,42 @@ func TestNewClient_Services(t *testing.T) {
 	}
 }
 
+func TestNewClient_TestErrNoInstanceGiven(t *testing.T) {
+	_, err := gerrit.NewClient("", nil)
+	if err != gerrit.ErrNoInstanceGiven {
+		t.Error("Expected `ErrNoInstanceGiven`")
+	}
+}
+
+func TestNewClientFromURL_NoCredentials(t *testing.T) {
+	client, err := gerrit.NewClientFromURL("http://localhost/", nil)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	if client.Authentication.HasAuth() {
+		t.Error("Expected HasAuth() to return false")
+	}
+}
+
+func TestNewClientFromURL_UsernameWithoutPassword(t *testing.T) {
+	_, err := gerrit.NewClientFromURL("http://foo@localhost/", nil)
+	if err != gerrit.ErrUserProvidedWithoutPassword {
+		t.Error("Expected ErrUserProvidedWithoutPassword")
+	}
+}
+
+func TestNewClientFromURL_AuthenticationFailed(t *testing.T) {
+	setup()
+	defer teardown()
+
+	serverURL := fmt.Sprintf("http://admin:secret@%s/", testServer.Listener.Addr().String())
+	_, err := gerrit.NewClientFromURL(serverURL, nil)
+
+	if err != gerrit.ErrAuthenticationFailed {
+		t.Error("Expected ErrAuthenticationFailed")
+	}
+}
+
 func TestNewRequest(t *testing.T) {
 	c, err := gerrit.NewClient(testGerritInstanceURL, nil)
 	if err != nil {
@@ -289,9 +325,3 @@ func TestRemoveMagicPrefixLineDoesNothingWithoutPrefix(t *testing.T) {
 	}
 }
 
-func TestErrNoInstanceGiven(t *testing.T) {
-	_, err := gerrit.NewClient("", nil)
-	if err != gerrit.ErrNoInstanceGiven {
-		t.Error("Expected `ErrNoInstanceGiven`")
-	}
-}

--- a/gerrit_test.go
+++ b/gerrit_test.go
@@ -2,17 +2,17 @@ package gerrit_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
-	"encoding/json"
 	"github.com/andygrunwald/go-gerrit"
-	"strings"
 )
 
 const (
@@ -173,7 +173,6 @@ func TestNewClientFromURL_AuthenticationFailed(t *testing.T) {
 	defer teardown()
 
 	testMux.HandleFunc("/a/accounts/self", func(w http.ResponseWriter, r *http.Request) {
-		// return StatusUnauthorized for every request.
 		writeresponse(t, w, nil, http.StatusUnauthorized)
 	})
 

--- a/gerrit_test.go
+++ b/gerrit_test.go
@@ -151,8 +151,8 @@ func TestNewClient_TestErrNoInstanceGiven(t *testing.T) {
 	}
 }
 
-func TestNewClientFromURL_NoCredentials(t *testing.T) {
-	client, err := gerrit.NewClientFromURL("http://localhost/", nil)
+func TestNewClient_NoCredentials(t *testing.T) {
+	client, err := gerrit.NewClient("http://localhost/", nil)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
 	}
@@ -161,14 +161,14 @@ func TestNewClientFromURL_NoCredentials(t *testing.T) {
 	}
 }
 
-func TestNewClientFromURL_UsernameWithoutPassword(t *testing.T) {
-	_, err := gerrit.NewClientFromURL("http://foo@localhost/", nil)
+func TestNewClient_UsernameWithoutPassword(t *testing.T) {
+	_, err := gerrit.NewClient("http://foo@localhost/", nil)
 	if err != gerrit.ErrUserProvidedWithoutPassword {
 		t.Error("Expected ErrUserProvidedWithoutPassword")
 	}
 }
 
-func TestNewClientFromURL_AuthenticationFailed(t *testing.T) {
+func TestNewClient_AuthenticationFailed(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -177,7 +177,7 @@ func TestNewClientFromURL_AuthenticationFailed(t *testing.T) {
 	})
 
 	serverURL := fmt.Sprintf("http://admin:secret@%s/", testServer.Listener.Addr().String())
-	client, err := gerrit.NewClientFromURL(serverURL, nil)
+	client, err := gerrit.NewClient(serverURL, nil)
 	if err != gerrit.ErrAuthenticationFailed {
 		t.Error(err)
 	}
@@ -186,7 +186,7 @@ func TestNewClientFromURL_AuthenticationFailed(t *testing.T) {
 	}
 }
 
-func TestNewClientFromURL_DigestAuth(t *testing.T) {
+func TestNewClient_DigestAuth(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -215,7 +215,7 @@ func TestNewClientFromURL_DigestAuth(t *testing.T) {
 	})
 
 	serverURL := fmt.Sprintf("http://admin:secret@%s/", testServer.Listener.Addr().String())
-	client, err := gerrit.NewClientFromURL(serverURL, nil)
+	client, err := gerrit.NewClient(serverURL, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -224,7 +224,7 @@ func TestNewClientFromURL_DigestAuth(t *testing.T) {
 	}
 }
 
-func TestNewClientFromURL_BasicAuth(t *testing.T) {
+func TestNewClient_BasicAuth(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -253,7 +253,7 @@ func TestNewClientFromURL_BasicAuth(t *testing.T) {
 	})
 
 	serverURL := fmt.Sprintf("http://admin:secret@%s/", testServer.Listener.Addr().String())
-	client, err := gerrit.NewClientFromURL(serverURL, nil)
+	client, err := gerrit.NewClient(serverURL, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -262,7 +262,7 @@ func TestNewClientFromURL_BasicAuth(t *testing.T) {
 	}
 }
 
-func TestNewClientFromURL_CookieAuth(t *testing.T) {
+func TestNewClient_CookieAuth(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -292,7 +292,7 @@ func TestNewClientFromURL_CookieAuth(t *testing.T) {
 	})
 
 	serverURL := fmt.Sprintf("http://admin:secret@%s/", testServer.Listener.Addr().String())
-	client, err := gerrit.NewClientFromURL(serverURL, nil)
+	client, err := gerrit.NewClient(serverURL, nil)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This PR updates `NewClient` to handle credentials in the url:

```go
client, err := gerrit.NewClient("http://user:secret@host:port/")
```

If the credentials are invalid then `err` will be set appropriately. This new function will be used in the `docker_tests` branch.

Another case were this could be useful is when a consumer of go-gerrit is using configuration files to drive their application. In these cases code could go from:

```go
username, password := GetCredentials()
client, err := gerrit.NewClient(GetURL())
client.Authentication.SetDigestAuth(username, password)
// test auth
```

To:

```go
client, err := gerrit.NewClient(GetURL())
// make sure err == nil
```