### PR TITLE
Fixes and Improvements for GetEvents()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ first. For more complete details see
 
 ## Versions
 
+### 0.2.0 (not yet released)
+
+**WARNING**: This release includes breaking changes.
+
+* [BREAKING CHANGE] Several bugfixes to GetEvents:
+  * Update EventInfo to handle the changeKey field and apply
+    the proper type for the Project field
+  * Provide a means to ignore marshaling errors
+  * Update GetEvents() to return the failed lines and remove
+    the pointer to the return value because it's unnecessary.
+
 ### 0.1.1
 
 * Minor fix to SubmitChange to use the `http.StatusConflict` constant

--- a/events.go
+++ b/events.go
@@ -74,6 +74,14 @@ type EventsLogService struct {
 type EventsLogOptions struct {
 	From time.Time
 	To   time.Time
+
+	// IgnoreUnmarshalErrors will cause GetEvents to ignore any errors
+	// that come up when calling json.Unmarshal. This can be useful in
+	// cases where the events-log plugin was not kept up to date with
+	// the Gerrit version for some reason. In these cases the events-log
+	// plugin will return data structs that don't match the EventInfo
+	// struct which in turn causes issues for json.Unmarshal.
+	IgnoreUnmarshalErrors bool
 }
 
 // getURL returns the url that should be used in the request.  This will vary
@@ -137,7 +145,7 @@ func (events *EventsLogService) GetEvents(options *EventsLogOptions) (*[]EventIn
 		if len(line) > 0 {
 			event := EventInfo{}
 			err := json.Unmarshal(line, &event)
-			if err != nil {
+			if err != nil && !options.IgnoreUnmarshalErrors {
 				return nil, nil, err
 			}
 			*eventInfo = append(*eventInfo, event)

--- a/events.go
+++ b/events.go
@@ -157,6 +157,7 @@ func (events *EventsLogService) GetEvents(options *EventsLogOptions) ([]EventInf
 				if !options.IgnoreUnmarshalErrors {
 					return info, response, failures, err
 				}
+				continue
 			}
 			info = append(info, event)
 		}

--- a/events.go
+++ b/events.go
@@ -41,6 +41,7 @@ type RefUpdate struct {
 type EventInfo struct {
 	Type           string        `json:"type"`
 	Change         ChangeInfo    `json:"change,omitempty"`
+	ChangeKey      ChangeInfo    `json:"changeKey,omitempty"`
 	PatchSet       PatchSet      `json:"patchSet,omitempty"`
 	EventCreatedOn int           `json:"eventCreatedOn,omitempty"`
 	Reason         string        `json:"reason,omitempty"`
@@ -56,7 +57,7 @@ type EventInfo struct {
 	Removed        []string      `json:"removed,omitempty"`
 	Hashtags       []string      `json:"hashtags,omitempty"`
 	RefUpdate      RefUpdate     `json:"refUpdate,omitempty"`
-	Project        string        `json:"project,omitempty"`
+	Project        ProjectInfo   `json:"project,omitempty"`
 	Reviewer       AccountInfo   `json:"reviewer,omitempty"`
 	OldTopic       string        `json:"oldTopic,omitempty"`
 	Changer        AccountInfo   `json:"changer,omitempty"`


### PR DESCRIPTION
This PR improves `GetEvents()` with a few changes:
- Update EventInfo to handle the `changeKey` field and apply the proper type for the Project field (e24573d)
- Provide a means to ignore marshaling errors (ac5aca8)
- Update GetEvents() to return the failed lines and remove the pointer to the return value because it's unnecessary (bf5e285).
