### PR TITLE
Add the missing URL field to ChangeInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ first. For more complete details see
   it easier to test against externally and also fixes a lint issue too.
 * Updated NewClient function to handle credentials in the url.
 * Added the missing `Submitted` field to `ChangeInfo`.
+* Added the missing `URL` field to `ChangeInfo` which is usually included
+  as part of an event from the events-log plugin.
 
 ### 0.1.0
 

--- a/changes.go
+++ b/changes.go
@@ -243,6 +243,7 @@ type DiffIntralineInfo []struct {
 // ChangeInfo entity contains information about a change.
 type ChangeInfo struct {
 	ID                 string                  `json:"id"`
+	URL                string                  `json:"url,omitempty"`
 	Project            string                  `json:"project"`
 	Branch             string                  `json:"branch"`
 	Topic              string                  `json:"topic,omitempty"`


### PR DESCRIPTION
This field is usually included as as part of an event from the events-log plugin.