### PR TITLE
update PublishChangeEdit: notify param

### DIFF
--- a/changes_edit.go
+++ b/changes_edit.go
@@ -153,7 +153,7 @@ func (s *ChangesService) DeleteChangeEdit(changeID, filePath string) (*Response,
 func (s *ChangesService) PublishChangeEdit(changeID, notify string)  (*Response, error) {
 	u := fmt.Sprintf("changes/%s/edit:publish", changeID)
 
-	req, err := s.client.NewRequest("POST", u, map[string]{
+	req, err := s.client.NewRequest("POST", u, map[string]string{
 		"notify": notify,
 	})
 	if err != nil {

--- a/changes_edit.go
+++ b/changes_edit.go
@@ -150,10 +150,12 @@ func (s *ChangesService) DeleteChangeEdit(changeID, filePath string) (*Response,
 // As response “204 No Content” is returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#publish-edit
-func (s *ChangesService) PublishChangeEdit(changeID string) (*Response, error) {
+func (s *ChangesService) PublishChangeEdit(changeID, notify string)  (*Response, error) {
 	u := fmt.Sprintf("changes/%s/edit:publish", changeID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, map[string]{
+		"notify": notify,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/changes_test.go
+++ b/changes_test.go
@@ -2,6 +2,8 @@ package gerrit_test
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 
 	"github.com/andygrunwald/go-gerrit"
 )
@@ -57,4 +59,21 @@ func ExampleChangesService_QueryChangesWithSymbols() {
 
 	// Output:
 	// Project: platform/art -> ART: Change return types of field access entrypoints -> https://android-review.googlesource.com/249244
+}
+
+func ExampleChangesService_PublishChangeEdit() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "ok")
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = client.Changes.PublishChangeEdit("123", "NONE")
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
This fixes a 400 I was getting when calling PublishChangeEdit on chromium-review.googlesource.com. It told me it expected a json body, so this adds one.