### PR TITLE
Fix ChangeFileContentInChangeEdit

### DIFF
--- a/changes_edit.go
+++ b/changes_edit.go
@@ -94,10 +94,10 @@ func (s *ChangesService) RetrieveCommitMessageFromChangeEdit(changeID string) (s
 // As response “204 No Content” is returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#put-edit-file
-func (s *ChangesService) ChangeFileContentInChangeEdit(changeID, filePath string) (*Response, error) {
-	u := fmt.Sprintf("changes/%s/edit/%s", changeID, filePath)
+func (s *ChangesService) ChangeFileContentInChangeEdit(changeID, filePath, content string) (*Response, error) {
+	u := fmt.Sprintf("changes/%s/edit/%s", changeID, url.QueryEscape(filePath))
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRawPutRequest(u, content)
 	if err != nil {
 		return nil, err
 	}

--- a/changes_edit.go
+++ b/changes_edit.go
@@ -2,6 +2,7 @@ package gerrit
 
 import (
 	"fmt"
+	"net/url"
 )
 
 // EditInfo entity contains information about a change edit.

--- a/changes_test.go
+++ b/changes_test.go
@@ -2,8 +2,6 @@ package gerrit_test
 
 import (
 	"fmt"
-        "net/http"
-        "net/http/httptest"
 
 	"github.com/andygrunwald/go-gerrit"
 )
@@ -59,21 +57,4 @@ func ExampleChangesService_QueryChangesWithSymbols() {
 
 	// Output:
 	// Project: platform/art -> ART: Change return types of field access entrypoints -> https://android-review.googlesource.com/249244
-}
-
-func ExampleChangesService_PublishChangeEdit() {
-        ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                fmt.Fprintf(w, "ok")
-        }))
-        defer ts.Close()
-
-        client, err := gerrit.NewClient(ts.URL, nil)
-        if err != nil {
-                panic(err)
-        }
-
-        _, err = client.Changes.PublishChangeEdit("123", "NONE")
-        if err != nil {
-                panic(err)
-        }
 }

--- a/changes_test.go
+++ b/changes_test.go
@@ -2,6 +2,8 @@ package gerrit_test
 
 import (
 	"fmt"
+        "net/http"
+        "net/http/httptest"
 
 	"github.com/andygrunwald/go-gerrit"
 )
@@ -57,4 +59,21 @@ func ExampleChangesService_QueryChangesWithSymbols() {
 
 	// Output:
 	// Project: platform/art -> ART: Change return types of field access entrypoints -> https://android-review.googlesource.com/249244
+}
+
+func ExampleChangesService_PublishChangeEdit() {
+        ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+                fmt.Fprintf(w, "ok")
+        }))
+        defer ts.Close()
+
+        client, err := gerrit.NewClient(ts.URL, nil)
+        if err != nil {
+                panic(err)
+        }
+
+        _, err = client.Changes.PublishChangeEdit("123", "NONE")
+        if err != nil {
+                panic(err)
+        }
 }

--- a/gerrit.go
+++ b/gerrit.go
@@ -218,6 +218,38 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	return req, nil
 }
 
+// NewRawPutRequest creates a raw PUT request and makes no attempt to encode
+// or marshal the body. Just passes it straight through.
+func (c *Client) NewRawPutRequest(urlStr string, body string) (*http.Request, error) {
+        // Build URL for request
+        u, err := c.buildURLForRequest(urlStr)
+        if err != nil {
+                return nil, err
+        }
+
+        buf := bytes.NewBuffer([]byte(body))
+        req, err := http.NewRequest("PUT", u, buf)
+        if err != nil {
+                return nil, err
+        }
+
+        // Apply Authentication
+        if err := c.addAuthentication(req); err != nil {
+                return nil, err
+        }
+
+        // Request compact JSON
+        // See https://gerrit-review.googlesource.com/Documentation/rest-api.html#output
+        req.Header.Add("Accept", "application/json")
+        req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+        // TODO: Add gzip encoding
+        // Accept-Encoding request header is set to gzip
+        // See https://gerrit-review.googlesource.com/Documentation/rest-api.html#output
+
+        return req, nil
+}
+
 // Call is a combine function for Client.NewRequest and Client.Do.
 //
 // Most API methods are quite the same.

--- a/gerrit_test.go
+++ b/gerrit_test.go
@@ -323,6 +323,27 @@ func TestNewRequest(t *testing.T) {
 	}
 }
 
+func TestNewRawPutRequest(t *testing.T) {
+        c, err := gerrit.NewClient(testGerritInstanceURL, nil)
+        if err != nil {
+                t.Errorf("An error occured. Expected nil. Got %+v.", err)
+        }
+
+        inURL, outURL := "/foo", testGerritInstanceURL+"foo"
+        req, _ := c.NewRawPutRequest(inURL, "test raw PUT contents")
+
+        // Test that relative URL was expanded
+        if got, want := req.URL.String(), outURL; got != want {
+                t.Errorf("NewRequest(%q) URL is %v, want %v", inURL, got, want)
+        }
+
+        // Test that body was JSON encoded
+        body, _ := ioutil.ReadAll(req.Body)
+        if got, want := string(body), "test raw PUT contents"; got != want {
+                t.Errorf("NewRequest Body is %v, want %v", got, want)
+        }
+}
+
 func testURLParseError(t *testing.T, err error) {
 	if err == nil {
 		t.Errorf("Expected error to be returned")


### PR DESCRIPTION
Another fix for making changes on chromium-review.googlesource.com.

This allows the caller to pass the new file contents as a string.