### PR TITLE
Simplify and optimize RemoveMagicPrefixLine.

### DIFF
--- a/gerrit.go
+++ b/gerrit.go
@@ -436,15 +436,13 @@ func (c *Client) DeleteRequest(urlStr string, body interface{}) (*Response, erro
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api.html#output
 func RemoveMagicPrefixLine(body []byte) []byte {
-	if bytes.HasPrefix(body, []byte(")]}'\n")) {
-		index := bytes.IndexByte(body, '\n')
-		if index > -1 {
-			// +1 to catch the \n as well
-			body = body[(index + 1):]
-		}
+	if bytes.HasPrefix(body, magicPrefix) {
+		return body[5:]
 	}
 	return body
 }
+
+var magicPrefix = []byte(")]}'\n")
 
 // CheckResponse checks the API response for errors, and returns them if present.
 // A response is considered an error if it has a status code outside the 200 range.


### PR DESCRIPTION
This PR implements a suggestion from https://github.com/andygrunwald/go-gerrit/pull/10/files#r116843309.

If body has `")]}'\n"` prefix, there's no need to use `bytes.IndexByte` to find the first `'\n'` character, it's known to be at index 4 because `bytes.HasPrefix(body, []byte(")]}'\n"))` was true.

Since this is called often, it's probably a good idea to factor out `[]byte(")]}'\n")` into a package scope variable, instead of potentially allocating once per `RemoveMagicPrefixLine` call.