### PR TITLE
Fix type of EventInfo.PatchSet.Number

### DIFF
--- a/events.go
+++ b/events.go
@@ -12,7 +12,7 @@ import (
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/json.html#patchSet
 type PatchSet struct {
-	Number    string      `json:"number"`
+	Number    Number      `json:"number"`
 	Revision  string      `json:"revision"`
 	Parents   []string    `json:"parents"`
 	Ref       string      `json:"ref"`

--- a/types.go
+++ b/types.go
@@ -1,0 +1,42 @@
+package gerrit
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+)
+
+
+// Number is a string representing a number. This type is only used in cases
+// where the API being queried may return an inconsistent result.
+type Number string
+
+// String returns the string representing the current number.
+func (n *Number) String() string {
+	return string(*n)
+}
+
+// Int returns the current number as an integer
+func (n *Number) Int() (int, error) {
+	return strconv.Atoi(n.String())
+}
+
+func (n *Number) UnmarshalJSON(data []byte) error {
+	// `data` is a number represented as a string (ex. "5").
+	var stringNumber string
+	if err := json.Unmarshal(data, &stringNumber); err == nil {
+		*n = Number(stringNumber)
+		return nil
+	}
+
+	// `data` is a number represented as an integer (ex. 5). Here
+	// we're using json.Unmarshal to convert bytes -> number which
+	// we then convert to our own Number type.
+	var number int
+	if err := json.Unmarshal(data, &number); err == nil {
+		*n = Number(strconv.Itoa(number))
+		return nil
+	}
+	return errors.New("Cannot convert data to number")
+}
+

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,49 @@
+package gerrit_test
+
+import (
+	"encoding/json"
+	"testing"
+	"github.com/andygrunwald/go-gerrit"
+)
+
+func TestTypesNumber_String(t *testing.T) {
+	number := gerrit.Number("7")
+	if number.String() != "7" {
+		t.Fatalf("%s != 7", number.String())
+	}
+}
+
+func TestTypesNumber_Int(t *testing.T) {
+	number := gerrit.Number("7")
+	integer, err := number.Int()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if integer != 7 {
+		t.Fatalf("%d != 7", integer)
+	}
+}
+
+func TestTypesNumber_UnmarshalJSON_String(t *testing.T) {
+	var number gerrit.Number
+	if err := json.Unmarshal([]byte(`"7"`), &number); err != nil {
+		t.Fatal(err)
+	}
+	if number.String() != "7" {
+		t.Fatalf("%s != 7", number.String())
+	}
+}
+
+func TestTypesNumber_UnmarshalJSON_Int(t *testing.T) {
+	var number gerrit.Number
+	if err := json.Unmarshal([]byte("7"), &number); err != nil {
+		t.Fatal(err)
+	}
+	integer, err := number.Int()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if integer != 7 {
+		t.Fatalf("%d != 7", integer)
+	}
+}


### PR DESCRIPTION
Depending on the version of the events-log plugin
and the version of Gerrit you can end up in a situation
where some values of EventInfo.PatchSet.Number are a
string and other are an integer. This change works around
the problem by replacing the Number field with a custom
type that can handle either strings or integers.

Note, this does not change the underlying type of the
Number field.