### PR TITLE
SetReview should return a ReviewResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ first. For more complete details see
 
 ## Versions
 
-### latest (not yet released)
+### 0.4.0
+
+**WARNING**: This release includes breaking changes.
+
+* [BREAKING CHANGE] The SetReview function was returning the wrong
+  entity type. (#40)
 
 ### 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ first. For more complete details see
 
 ## Versions
 
-### 0.4.0
+### 0.5.0
 
 **WARNING**: This release includes breaking changes.
 

--- a/changes.go
+++ b/changes.go
@@ -149,6 +149,14 @@ type ReviewInfo struct {
 	Labels map[string]int `json:"labels"`
 }
 
+// ReviewResult entity contains information regarding the updates that were
+// made to a review.
+type ReviewResult struct {
+	ReviewInfo
+	Reviewers map[string]AddReviewerResult `json:"reviewers,omitempty"`
+	Ready     bool                         `json:"ready,omitempty"`
+}
+
 // TopicInput entity contains information for setting a topic.
 type TopicInput struct {
 	Topic string `json:"topic,omitempty"`

--- a/changes_reviewer.go
+++ b/changes_reviewer.go
@@ -18,7 +18,9 @@ type SuggestedReviewerInfo struct {
 
 // AddReviewerResult entity describes the result of adding a reviewer to a change.
 type AddReviewerResult struct {
+	Input     string         `json:"input,omitempty"`
 	Reviewers []ReviewerInfo `json:"reviewers,omitempty"`
+	CCS       []ReviewerInfo `json:"ccs,omitempty"`
 	Error     string         `json:"error,omitempty"`
 	Confirm   bool           `json:"confirm,omitempty"`
 }

--- a/changes_revision.go
+++ b/changes_revision.go
@@ -343,7 +343,7 @@ func (s *ChangesService) ListFilesReviewed(changeID, revisionID string) (*[]File
 // The review must be provided in the request body as a ReviewInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-review
-func (s *ChangesService) SetReview(changeID, revisionID string, input *ReviewInput) (*ReviewInfo, *Response, error) {
+func (s *ChangesService) SetReview(changeID, revisionID string, input *ReviewInput) (*ReviewResult, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/review", changeID, revisionID)
 
 	req, err := s.client.NewRequest("POST", u, input)
@@ -351,7 +351,7 @@ func (s *ChangesService) SetReview(changeID, revisionID string, input *ReviewInp
 		return nil, nil, err
 	}
 
-	v := new(ReviewInfo)
+	v := new(ReviewResult)
 	resp, err := s.client.Do(req, v)
 	if err != nil {
 		return nil, resp, err


### PR DESCRIPTION
The REST api for Gerrit states that:

  As response a ReviewResult entity is returned that describes the
  applied labels and any added reviewers (e.g. yourself, if you set
  a label but weren’t previously a reviewer on this CL).

go-gerrit however was returning a ReviewInfo entity that was missing
the reviewers and ready fields.