### PR TITLE
Add missing AbandonChange, RebaseChange, RestoreChange and RevertChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ first. For more complete details see
 
 ### 0.5.1
 
-* Added the `AbandonChange` function.
+* Added the `AbandonChange` and `RebaseChange` functions.
 
 ### 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ first. For more complete details see
 
 ### 0.5.1
 
-* Added the `AbandonChange`, `RebaseChange` and `RestoreChange` functions.
+* Added the `AbandonChange`, `RebaseChange`, `RestoreChange` and 
+  `RevertChange` functions.
 
 ### 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ first. For more complete details see
 
 ### 0.5.1
 
-* Added the `AbandonChange` and `RebaseChange` functions.
+* Added the `AbandonChange`, `RebaseChange` and `RestoreChange` functions.
 
 ### 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ first. For more complete details see
 
 ## Versions
 
+### 0.5.1
+
+* Added the `AbandonChange` function.
+
 ### 0.5.0
 
 **WARNING**: This release includes breaking changes.

--- a/changes.go
+++ b/changes.go
@@ -786,8 +786,27 @@ func (s *ChangesService) RestoreChange(changeID string, input *RestoreInput) (*C
 	return v, resp, err
 }
 
+// RevertChange reverts a change.
+//
+// The request body does not need to include a RevertInput entity if no
+// review comment is added.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#revert-change
+func (s *ChangesService) RevertChange(changeID string, input *RevertInput) (*ChangeInfo, *Response, error) {
+	u := fmt.Sprintf("changes/%s/revert", changeID)
 
-/*
-Missing Change Endpoints
-	Revert Change
-*/
+	req, err := s.client.NewRequest("POST", u, input)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(ChangeInfo)
+
+	resp, err := s.client.Do(req, v)
+	if resp.StatusCode == http.StatusConflict {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err = errors.New(string(body[:]))
+	}
+	return v, resp, err
+}
+

--- a/changes.go
+++ b/changes.go
@@ -762,8 +762,32 @@ func (s *ChangesService) RebaseChange(changeID string, input *RebaseInput) (*Cha
 	return v, resp, err
 }
 
+// RestoreChange restores a change.
+//
+// The request body does not need to include a RestoreInput entity if no review
+// comment is added.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#restore-change
+func (s *ChangesService) RestoreChange(changeID string, input *RestoreInput) (*ChangeInfo, *Response, error) {
+	u := fmt.Sprintf("changes/%s/restore", changeID)
+
+	req, err := s.client.NewRequest("POST", u, input)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(ChangeInfo)
+
+	resp, err := s.client.Do(req, v)
+	if resp.StatusCode == http.StatusConflict {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err = errors.New(string(body[:]))
+	}
+	return v, resp, err
+}
+
+
 /*
 Missing Change Endpoints
-	Restore Change
 	Revert Change
 */

--- a/changes.go
+++ b/changes.go
@@ -809,4 +809,3 @@ func (s *ChangesService) RevertChange(changeID string, input *RevertInput) (*Cha
 	}
 	return v, resp, err
 }
-

--- a/changes.go
+++ b/changes.go
@@ -716,6 +716,9 @@ func (s *ChangesService) SubmitChange(changeID string, input *SubmitInput) (*Cha
 
 // AbandonChange abandons a change.
 //
+// The request body does not need to include a AbandonInput entity if no review
+// comment is added.
+//
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#abandon-change
 func (s *ChangesService) AbandonChange(changeID string, input *AbandonInput) (*ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/abandon", changeID)
@@ -735,9 +738,32 @@ func (s *ChangesService) AbandonChange(changeID string, input *AbandonInput) (*C
 	return v, resp, err
 }
 
+// RebaseChange rebases a change.
+//
+// Optionally, the parent revision can be changed to another patch set through
+// the RebaseInput entity.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#rebase-change
+func (s *ChangesService) RebaseChange(changeID string, input *RebaseInput) (*ChangeInfo, *Response, error) {
+	u := fmt.Sprintf("changes/%s/rebase", changeID)
+
+	req, err := s.client.NewRequest("POST", u, input)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(ChangeInfo)
+
+	resp, err := s.client.Do(req, v)
+	if resp.StatusCode == http.StatusConflict {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err = errors.New(string(body[:]))
+	}
+	return v, resp, err
+}
+
 /*
 Missing Change Endpoints
 	Restore Change
-	Rebase Change
 	Revert Change
 */

--- a/changes.go
+++ b/changes.go
@@ -691,27 +691,31 @@ func (s *ChangesService) FixChange(changeID string, input *FixInput) (*ChangeInf
 	return v, resp, err
 }
 
-// SubmitChange submits a change.
-//
-// The request body only needs to include a SubmitInput entity if submitting on behalf of another user.
-//
-// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#submit-change
-func (s *ChangesService) SubmitChange(changeID string, input *SubmitInput) (*ChangeInfo, *Response, error) {
-	u := fmt.Sprintf("changes/%s/submit", changeID)
-
+// change is an internal function to consolidate code used by SubmitChange,
+// AbandonChange and other similar functions.
+func (s *ChangesService) change(tail string, changeID string, input interface{}) (*ChangeInfo, *Response, error) {
+	u := fmt.Sprintf("changes/%s/%s", changeID, tail)
 	req, err := s.client.NewRequest("POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	v := new(ChangeInfo)
-
 	resp, err := s.client.Do(req, v)
 	if resp.StatusCode == http.StatusConflict {
 		body, _ := ioutil.ReadAll(resp.Body)
 		err = errors.New(string(body[:]))
 	}
 	return v, resp, err
+}
+
+// SubmitChange submits a change.
+//
+// The request body only needs to include a SubmitInput entity if submitting on behalf of another user.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#submit-change
+func (s *ChangesService) SubmitChange(changeID string, input *SubmitInput) (*ChangeInfo, *Response, error) {
+	return s.change("submit", changeID, input)
 }
 
 // AbandonChange abandons a change.
@@ -721,21 +725,7 @@ func (s *ChangesService) SubmitChange(changeID string, input *SubmitInput) (*Cha
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#abandon-change
 func (s *ChangesService) AbandonChange(changeID string, input *AbandonInput) (*ChangeInfo, *Response, error) {
-	u := fmt.Sprintf("changes/%s/abandon", changeID)
-
-	req, err := s.client.NewRequest("POST", u, input)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	v := new(ChangeInfo)
-
-	resp, err := s.client.Do(req, v)
-	if resp.StatusCode == http.StatusConflict {
-		body, _ := ioutil.ReadAll(resp.Body)
-		err = errors.New(string(body[:]))
-	}
-	return v, resp, err
+	return s.change("abandon", changeID, input)
 }
 
 // RebaseChange rebases a change.
@@ -745,21 +735,7 @@ func (s *ChangesService) AbandonChange(changeID string, input *AbandonInput) (*C
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#rebase-change
 func (s *ChangesService) RebaseChange(changeID string, input *RebaseInput) (*ChangeInfo, *Response, error) {
-	u := fmt.Sprintf("changes/%s/rebase", changeID)
-
-	req, err := s.client.NewRequest("POST", u, input)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	v := new(ChangeInfo)
-
-	resp, err := s.client.Do(req, v)
-	if resp.StatusCode == http.StatusConflict {
-		body, _ := ioutil.ReadAll(resp.Body)
-		err = errors.New(string(body[:]))
-	}
-	return v, resp, err
+	return s.change("rebase", changeID, input)
 }
 
 // RestoreChange restores a change.
@@ -769,21 +745,7 @@ func (s *ChangesService) RebaseChange(changeID string, input *RebaseInput) (*Cha
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#restore-change
 func (s *ChangesService) RestoreChange(changeID string, input *RestoreInput) (*ChangeInfo, *Response, error) {
-	u := fmt.Sprintf("changes/%s/restore", changeID)
-
-	req, err := s.client.NewRequest("POST", u, input)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	v := new(ChangeInfo)
-
-	resp, err := s.client.Do(req, v)
-	if resp.StatusCode == http.StatusConflict {
-		body, _ := ioutil.ReadAll(resp.Body)
-		err = errors.New(string(body[:]))
-	}
-	return v, resp, err
+	return s.change("restore", changeID, input)
 }
 
 // RevertChange reverts a change.
@@ -793,19 +755,5 @@ func (s *ChangesService) RestoreChange(changeID string, input *RestoreInput) (*C
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#revert-change
 func (s *ChangesService) RevertChange(changeID string, input *RevertInput) (*ChangeInfo, *Response, error) {
-	u := fmt.Sprintf("changes/%s/revert", changeID)
-
-	req, err := s.client.NewRequest("POST", u, input)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	v := new(ChangeInfo)
-
-	resp, err := s.client.Do(req, v)
-	if resp.StatusCode == http.StatusConflict {
-		body, _ := ioutil.ReadAll(resp.Body)
-		err = errors.New(string(body[:]))
-	}
-	return v, resp, err
+	return s.change("revert", changeID, input)
 }

--- a/changes_test.go
+++ b/changes_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 
 	"github.com/andygrunwald/go-gerrit"
 )
@@ -75,5 +76,195 @@ func ExampleChangesService_PublishChangeEdit() {
 	_, err = client.Changes.PublishChangeEdit("123", "NONE")
 	if err != nil {
 		panic(err)
+	}
+}
+
+func TestChangesService_SubmitChange(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes/123/submit" {
+			t.Errorf("%s != /changes/123/submit", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"id": "123"}`)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	info, _, err := client.Changes.SubmitChange("123", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if info.ID != "123" {
+		t.Error("Invalid id")
+	}
+}
+
+func TestChangesService_SubmitChange_Conflict(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	_, response, _ := client.Changes.SubmitChange("123", nil)
+	if response.StatusCode != http.StatusConflict {
+		t.Error()
+	}
+}
+
+func TestChangesService_AbandonChange(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes/123/abandon" {
+			t.Errorf("%s != /changes/123/abandon", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"id": "123"}`)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	info, _, err := client.Changes.AbandonChange("123", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if info.ID != "123" {
+		t.Error("Invalid id")
+	}
+}
+
+func TestChangesService_AbandonChange_Conflict(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	_, response, _ := client.Changes.AbandonChange("123", nil)
+	if response.StatusCode != http.StatusConflict {
+		t.Error()
+	}
+}
+
+func TestChangesService_RebaseChange(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes/123/rebase" {
+			t.Errorf("%s != /changes/123/rebase", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"id": "123"}`)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	info, _, err := client.Changes.RebaseChange("123", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if info.ID != "123" {
+		t.Error("Invalid id")
+	}
+}
+
+func TestChangesService_RebaseChange_Conflict(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	_, response, _ := client.Changes.RebaseChange("123", nil)
+	if response.StatusCode != http.StatusConflict {
+		t.Error()
+	}
+}
+
+func TestChangesService_RestoreChange(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes/123/restore" {
+			t.Errorf("%s != /changes/123/restore", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"id": "123"}`)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	info, _, err := client.Changes.RestoreChange("123", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if info.ID != "123" {
+		t.Error("Invalid id")
+	}
+}
+
+func TestChangesService_RestoreChange_Conflict(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	_, response, _ := client.Changes.RestoreChange("123", nil)
+	if response.StatusCode != http.StatusConflict {
+		t.Error()
+	}
+}
+
+func TestChangesService_RevertChange(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes/123/revert" {
+			t.Errorf("%s != /changes/123/revert", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"id": "123"}`)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	info, _, err := client.Changes.RevertChange("123", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if info.ID != "123" {
+		t.Error("Invalid id")
+	}
+}
+
+func TestChangesService_RevertChange_Conflict(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	_, response, _ := client.Changes.RevertChange("123", nil)
+	if response.StatusCode != http.StatusConflict {
+		t.Error()
 	}
 }

--- a/changes_test.go
+++ b/changes_test.go
@@ -113,7 +113,7 @@ func TestChangesService_SubmitChange_Conflict(t *testing.T) {
 	}
 	_, response, _ := client.Changes.SubmitChange("123", nil)
 	if response.StatusCode != http.StatusConflict {
-		t.Error()
+		t.Error("Expected 409 code")
 	}
 }
 
@@ -151,7 +151,7 @@ func TestChangesService_AbandonChange_Conflict(t *testing.T) {
 	}
 	_, response, _ := client.Changes.AbandonChange("123", nil)
 	if response.StatusCode != http.StatusConflict {
-		t.Error()
+		t.Error("Expected 409 code")
 	}
 }
 
@@ -189,7 +189,7 @@ func TestChangesService_RebaseChange_Conflict(t *testing.T) {
 	}
 	_, response, _ := client.Changes.RebaseChange("123", nil)
 	if response.StatusCode != http.StatusConflict {
-		t.Error()
+		t.Error("Expected 409 code")
 	}
 }
 
@@ -227,7 +227,7 @@ func TestChangesService_RestoreChange_Conflict(t *testing.T) {
 	}
 	_, response, _ := client.Changes.RestoreChange("123", nil)
 	if response.StatusCode != http.StatusConflict {
-		t.Error()
+		t.Error("Expected 409 code")
 	}
 }
 
@@ -265,6 +265,6 @@ func TestChangesService_RevertChange_Conflict(t *testing.T) {
 	}
 	_, response, _ := client.Changes.RevertChange("123", nil)
 	if response.StatusCode != http.StatusConflict {
-		t.Error()
+		t.Error("Expected 409 code")
 	}
 }


### PR DESCRIPTION
Discovered AbandonChange was missing when I was working on [Change.Abandon()](https://github.com/opalmer/gerrittest/commit/72bedb205cc02d0fba3547f6f37edbc26021bf56#diff-a1b195d80625ef162eb4bf5d2a6cceb4R124) in gerrittest. Figured I'd implement it in go-gerrit and the other missing functions too since they're nearly identical.