### PR TITLE
Fix panic in checkAuth() if Gerrit is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ first. For more complete details see
 
 ## Versions
 
+### 0.5.2 (unreleased)
+
+* Fix panic in checkAuth() if Gerrit is down #42
+
 ### 0.5.1
 
 * Added the `AbandonChange`, `RebaseChange`, `RestoreChange` and 

--- a/gerrit.go
+++ b/gerrit.go
@@ -195,6 +195,12 @@ func checkAuth(client *Client) (bool, error) {
 	case ErrWWWAuthenticateHeaderNotDigest:
 		return false, nil
 	default:
+		// Response could be nil if the connection outright failed
+		// or some other error occurred before we got a response.
+		if response == nil && err != nil {
+			return false, err
+		}
+
 		if err != nil && response.StatusCode == http.StatusUnauthorized {
 			err = nil
 		}

--- a/gerrit_test.go
+++ b/gerrit_test.go
@@ -581,3 +581,16 @@ func TestRemoveMagicPrefixLineDoesNothingWithoutPrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestNewClientFailsOnDeadConnection(t *testing.T) {
+	setup()
+	serverURL := fmt.Sprintf("http://admin:secret@%s/", testServer.Listener.Addr().String())
+	teardown() // Closes the server
+	_, err := gerrit.NewClient(serverURL, nil)
+	if err == nil {
+		t.Fatal("Expected err to not be nil")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("Unexpected error. 'connected refused' not found in %s", err.Error())
+	}
+}


### PR DESCRIPTION
Previously checkAuth() would fail if the socket
we expected to find Gerrit running on didn't
have anything listning. This would result in
the connection be refused and no response being
sent from GetAccount().

The checkAuth() function was always expecting
some kind of response which in turn caused the
panic.