### PR TITLE
Fixed #44.

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -229,9 +229,9 @@ type RelatedChangeAndCommitInfo struct {
 
 // DiffContent entity contains information about the content differences in a file.
 type DiffContent struct {
-	A      string            `json:"a,omitempty"`
-	B      string            `json:"b,omitempty"`
-	AB     string            `json:"ab,omitempty"`
+	A      []string          `json:"a,omitempty"`
+	B      []string          `json:"b,omitempty"`
+	AB     []string          `json:"ab,omitempty"`
 	EditA  DiffIntralineInfo `json:"edit_a,omitempty"`
 	EditB  DiffIntralineInfo `json:"edit_b,omitempty"`
 	Skip   int               `json:"skip,omitempty"`
@@ -251,10 +251,7 @@ type CommentInput struct {
 }
 
 // DiffIntralineInfo entity contains information about intraline edits in a file.
-type DiffIntralineInfo []struct {
-	SkipLength int
-	MarkLength int
-}
+type DiffIntralineInfo [][2]int
 
 // ChangeInfo entity contains information about a change.
 type ChangeInfo struct {

--- a/changes.go
+++ b/changes.go
@@ -240,17 +240,27 @@ type DiffContent struct {
 
 // CommentInput entity contains information for creating an inline comment.
 type CommentInput struct {
-	ID        string       `json:"id,omitempty"`
-	Path      string       `json:"path,omitempty"`
-	Side      string       `json:"side,omitempty"`
-	Line      int          `json:"line,omitempty"`
-	Range     CommentRange `json:"range,omitempty"`
-	InReplyTo string       `json:"in_reply_to,omitempty"`
-	Updated   string       `json:"updated,omitempty"`
-	Message   string       `json:"message,omitempty"`
+	ID        string        `json:"id,omitempty"`
+	Path      string        `json:"path,omitempty"`
+	Side      string        `json:"side,omitempty"`
+	Line      int           `json:"line,omitempty"`
+	Range     *CommentRange `json:"range,omitempty"`
+	InReplyTo string        `json:"in_reply_to,omitempty"`
+	Updated   string        `json:"updated,omitempty"`
+	Message   string        `json:"message,omitempty"`
 }
 
 // DiffIntralineInfo entity contains information about intraline edits in a file.
+//
+// The information consists of a list of <skip length, mark length> pairs,
+// where the skip length is the number of characters between the end of
+// the previous edit and the start of this edit, and the mark length is the
+// number of edited characters following the skip. The start of the edits
+// is from the beginning of the related diff content lines.
+//
+// Note that the implied newline character at the end of each line
+// is included in the length calculation, and thus it is possible for
+// the edits to span newlines.
 type DiffIntralineInfo [][2]int
 
 // ChangeInfo entity contains information about a change.


### PR DESCRIPTION
DiffContent.A/B/AB should be []string instead of string.
DiffIntralineInfo should be [][2]int.