### PR TITLE
Updated S parameter according to the Gerrit API

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -391,8 +391,8 @@ type ChangeOptions struct {
 func (s *ChangesService) QueryChanges(opt *QueryChangeOptions) (*[]ChangeInfo, *Response, error) {
 	u := "changes/"
 
-	if !(opt.Skip == opt.Start) || ((opt.Skip == 0) || (opt.Start == 0)) {
-		return nil, nil, fmt.Errorf("the query parameters `skip`/`S`(=%v)) and `start` (=%v) are conflicting", opt.Skip, opt.Start)
+	if !(opt.Skip == opt.Start || opt.Skip == 0 || opt.Start == 0) {
+		return nil, nil, fmt.Errorf("the query parameters `skip`/`S`(=%v) and `start` (=%v) are conflicting", opt.Skip, opt.Start)
 	}
 
 	u, err := addOptions(u, opt)

--- a/changes.go
+++ b/changes.go
@@ -366,7 +366,6 @@ type QueryChangeOptions struct {
 
 	// The S or start query parameter can be supplied to skip a number of changes from the list.
 	Skip  int `url:"S,omitempty"`
-	Start int `url:"start,omitempty"`
 
 	ChangeOptions
 }

--- a/changes.go
+++ b/changes.go
@@ -391,8 +391,8 @@ type ChangeOptions struct {
 func (s *ChangesService) QueryChanges(opt *QueryChangeOptions) (*[]ChangeInfo, *Response, error) {
 	u := "changes/"
 
-	if !(opt.Skip == opt.Start) || (opt.Skip == 0) || (opt.Start == 0) {
-		return nil, nil, errors.New("the query parameters `skip` (`S`) and `start` are conflicting")
+	if !(opt.Skip == opt.Start) || ((opt.Skip == 0) || (opt.Start == 0)) {
+		return nil, nil, fmt.Errorf("the query parameters `skip`/`S`(=%v)) and `start` (=%v) are conflicting", opt.Skip, opt.Start)
 	}
 
 	u, err := addOptions(u, opt)

--- a/changes.go
+++ b/changes.go
@@ -391,7 +391,7 @@ type ChangeOptions struct {
 func (s *ChangesService) QueryChanges(opt *QueryChangeOptions) (*[]ChangeInfo, *Response, error) {
 	u := "changes/"
 
-	if (opt.Skip == opt.Start) || (opt.Skip == 0) || (opt.Start == 0) {
+	if !(opt.Skip == opt.Start) || (opt.Skip == 0) || (opt.Start == 0) {
 		return nil, nil, errors.New("the query parameters `skip` (`S`) and `start` are conflicting")
 	}
 

--- a/changes.go
+++ b/changes.go
@@ -365,7 +365,7 @@ type QueryChangeOptions struct {
 	QueryOptions
 
 	// The S or start query parameter can be supplied to skip a number of changes from the list.
-	Skip  int `url:"S,omitempty"`
+	Skip int `url:"S,omitempty"`
 
 	ChangeOptions
 }

--- a/changes.go
+++ b/changes.go
@@ -364,8 +364,9 @@ type QueryOptions struct {
 type QueryChangeOptions struct {
 	QueryOptions
 
-	// The S or start query parameter can be supplied to skip a number of changes from the list.
-	Skip int `url:"S,omitempty"`
+	// The S or start query parameter can be supplied to skip a number of changes from the list. Only one of the two parameters can be set at a time.
+	Skip  int `url:"S,omitempty"`
+	Start int `url:"start,omitempty"`
 
 	ChangeOptions
 }
@@ -389,6 +390,10 @@ type ChangeOptions struct {
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-changes
 func (s *ChangesService) QueryChanges(opt *QueryChangeOptions) (*[]ChangeInfo, *Response, error) {
 	u := "changes/"
+
+	if (opt.Skip == opt.Start) || (opt.Skip == 0) || (opt.Start == 0) {
+		return nil, nil, errors.New("the query parameters `skip` (`S`) and `start` are conflicting")
+	}
 
 	u, err := addOptions(u, opt)
 	if err != nil {

--- a/projects.go
+++ b/projects.go
@@ -193,7 +193,7 @@ type ProjectOptions struct {
 	Regex string `url:"r,omitempty"`
 
 	// Skip the given number of projects from the beginning of the list.
-	Skip string `url:"S,omitempty"`
+	Start string `url:"start,omitempty"`
 
 	// Limit the results to those projects that match the specified substring.
 	Substring string `url:"m,omitempty"`

--- a/projects.go
+++ b/projects.go
@@ -171,7 +171,7 @@ type ProjectBaseOptions struct {
 	Limit int `url:"n,omitempty"`
 
 	// Skip the given number of branches from the beginning of the list.
-	Skip string `url:"s,omitempty"`
+	Skip string `url:"S,omitempty"`
 }
 
 // ProjectOptions specifies the parameters to the ProjectsService.ListProjects.

--- a/projects_branch.go
+++ b/projects_branch.go
@@ -32,7 +32,7 @@ type BranchOptions struct {
 	Limit int `url:"n,omitempty"`
 
 	// Skip the given number of branches from the beginning of the list.
-	Skip string `url:"s,omitempty"`
+	Skip string `url:"S,omitempty"`
 
 	// Substring limits the results to those projects that match the specified substring.
 	Substring string `url:"m,omitempty"`


### PR DESCRIPTION
changed all occurrences of the `S` parameter according to the Gerrit API ("The `S` or `start` query parameter can be supplied to skip a number of changes from the list.")