### PR TITLE
Add FilesOptions to ListFiles, ListFilesReviewed; add missing fields.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: go
 sudo: false
 
 go:
-    - 1.6
-    - 1.7
-    - 1.8
-    - 1.9
+  - "1.10.x"
+  - "1.9.x"
+  - "1.8.x"
 
 before_install:
   - make deps

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ go-gerrit is a [Go(lang)](https://golang.org/) client library for accessing the 
 
 ## Installation
 
+go-gerrit requires Go version 1.8 or greater.
+
 It is go gettable ...
 
 ```sh
@@ -45,8 +47,8 @@ $ go test -v
 
 ```sh
 $ cd $GOPATH/src/github.com/andygrunwald/go-gerrit
-$ make 
-``` 
+$ make
+```
 
 ## API / Usage
 

--- a/changes.go
+++ b/changes.go
@@ -69,6 +69,7 @@ type ChangeMessageInfo struct {
 	Author         AccountInfo `json:"author,omitempty"`
 	Date           string      `json:"date"`
 	Message        string      `json:"message"`
+	Tag            string      `json:"tag,omitempty"`
 	RevisionNumber int         `json:"_revision_number,omitempty"`
 }
 

--- a/changes_revision.go
+++ b/changes_revision.go
@@ -28,6 +28,8 @@ type FileInfo struct {
 	OldPath       string `json:"old_path,omitempty"`
 	LinesInserted int    `json:"lines_inserted,omitempty"`
 	LinesDeleted  int    `json:"lines_deleted,omitempty"`
+	SizeDelta     int    `json:"size_delta"`
+	Size          int    `json:"size"`
 }
 
 // ActionInfo entity describes a REST API call the client can make to manipulate a resource.

--- a/changes_revision.go
+++ b/changes_revision.go
@@ -2,6 +2,7 @@ package gerrit
 
 import (
 	"fmt"
+	"net/url"
 )
 
 // DiffInfo entity contains information about the diff of a file in a revision.
@@ -64,8 +65,14 @@ type DiffOptions struct {
 	// If the intraline parameter is specified, intraline differences are included in the diff.
 	Intraline bool `url:"intraline,omitempty"`
 
-	//The base parameter can be specified to control the base patch set from which the diff should be generated.
-	Base bool `url:"base,omitempty"`
+	// The base parameter can be specified to control the base patch set from which the diff
+	// should be generated.
+	Base string `url:"base,omitempty"`
+
+	// The integer-valued request parameter parent can be specified to control the parent commit number
+	// against which the diff should be generated. This is useful for supporting review of merge commits.
+	// The value is the 1-based index of the parent’s position in the commit object.
+	Parent int `url:"parent,omitempty"`
 
 	// If the weblinks-only parameter is specified, only the diff web links are returned.
 	WeblinksOnly bool `url:"weblinks-only,omitempty"`
@@ -94,6 +101,28 @@ type MergableOptions struct {
 	OtherBranches bool `url:"other-branches,omitempty"`
 }
 
+// FilesOptions specifies the parameters for ListFiles and ListFilesReviewed calls.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-files
+type FilesOptions struct {
+	// The request parameter q changes the response to return a list of all files (modified or unmodified)
+	// that contain that substring in the path name. This is useful to implement suggestion services
+	// finding a file by partial name.
+	Q string `url:"q,omitempty"`
+
+	// The base parameter can be specified to control the base patch set from which the list of files
+	// should be generated.
+	//
+	// Note: This option is undocumented.
+	Base string `url:"base,omitempty"`
+
+	// The integer-valued request parameter parent changes the response to return a list of the files
+	// which are different in this commit compared to the given parent commit. This is useful for
+	// supporting review of merge commits. The value is the 1-based index of the parent’s position
+	// in the commit object.
+	Parent int `url:"parent,omitempty"`
+}
+
 // PatchOptions specifies the parameters for GetPatch call.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-patch
@@ -114,7 +143,7 @@ type PatchOptions struct {
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-diff
 func (s *ChangesService) GetDiff(changeID, revisionID, fileID string, opt *DiffOptions) (*DiffInfo, *Response, error) {
-	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/diff", changeID, revisionID, fileID)
+	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/diff", changeID, revisionID, url.PathEscape(fileID))
 
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -289,41 +318,8 @@ func (s *ChangesService) ListRevisionComments(changeID, revisionID string) (*map
 // The entries in the map are sorted by file path.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-files
-func (s *ChangesService) ListFiles(changeID, revisionID string) (*map[string]FileInfo, *Response, error) {
-	// TODO: Missing q parameter
-	// The request parameter q changes the response to return a list of all files (modified or unmodified) that contain that substring in the path name. This is useful to implement suggestion services finding a file by partial name.
+func (s *ChangesService) ListFiles(changeID, revisionID string, opt *FilesOptions) (map[string]FileInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/files/", changeID, revisionID)
-
-	req, err := s.client.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	v := new(map[string]FileInfo)
-	resp, err := s.client.Do(req, v)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return v, resp, err
-}
-
-// ListFilesReviewed lists the files that were modified, added or deleted in a revision.
-// The difference between ListFiles and ListFilesReviewed is that the caller has marked these files as reviewed.
-// Clients that also need the FileInfo should make two requests.
-//
-// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-files
-func (s *ChangesService) ListFilesReviewed(changeID, revisionID string) (*[]FileInfo, *Response, error) {
-	// TODO: Missing q parameter
-	// The request parameter q changes the response to return a list of all files (modified or unmodified) that contain that substring in the path name. This is useful to implement suggestion services finding a file by partial name.
-	u := fmt.Sprintf("changes/%s/revisions/%s/files/", changeID, revisionID)
-
-	opt := struct {
-		// The request parameter reviewed changes the response to return a list of the paths the caller has marked as reviewed.
-		Reviewed bool `url:"reviewed,omitempty"`
-	}{
-		Reviewed: true,
-	}
 
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -335,8 +331,46 @@ func (s *ChangesService) ListFilesReviewed(changeID, revisionID string) (*[]File
 		return nil, nil, err
 	}
 
-	v := new([]FileInfo)
-	resp, err := s.client.Do(req, v)
+	var v map[string]FileInfo
+	resp, err := s.client.Do(req, &v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
+// ListFilesReviewed lists the files that were modified, added or deleted in a revision.
+// Unlike ListFiles, the response of ListFilesReviewed is a list of the paths the caller
+// has marked as reviewed. Clients that also need the FileInfo should make two requests.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-files
+func (s *ChangesService) ListFilesReviewed(changeID, revisionID string, opt *FilesOptions) ([]string, *Response, error) {
+	u := fmt.Sprintf("changes/%s/revisions/%s/files/", changeID, revisionID)
+
+	o := struct {
+		// The request parameter reviewed changes the response to return a list of the paths the caller has marked as reviewed.
+		Reviewed bool `url:"reviewed,omitempty"`
+
+		FilesOptions
+	}{
+		Reviewed: true,
+	}
+	if opt != nil {
+		o.FilesOptions = *opt
+	}
+	u, err := addOptions(u, o)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var v []string
+	resp, err := s.client.Do(req, &v)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -525,7 +559,7 @@ func (s *ChangesService) DeleteDraft(changeID, revisionID, draftID string) (*Res
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-reviewed
 func (s *ChangesService) DeleteReviewed(changeID, revisionID, fileID string) (*Response, error) {
-	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/reviewed", changeID, revisionID, fileID)
+	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/reviewed", changeID, revisionID, url.PathEscape(fileID))
 	return s.client.DeleteRequest(u, nil)
 }
 
@@ -536,7 +570,7 @@ func (s *ChangesService) DeleteReviewed(changeID, revisionID, fileID string) (*R
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-content
 func (s *ChangesService) GetContent(changeID, revisionID, fileID string) (*string, *Response, error) {
-	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/content", changeID, revisionID, fileID)
+	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/content", changeID, revisionID, url.PathEscape(fileID))
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -560,7 +594,7 @@ func (s *ChangesService) GetContent(changeID, revisionID, fileID string) (*strin
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-content
 func (s *ChangesService) GetContentType(changeID, revisionID, fileID string) (*Response, error) {
-	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/content", changeID, revisionID, fileID)
+	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/content", changeID, revisionID, url.PathEscape(fileID))
 
 	req, err := s.client.NewRequest("HEAD", u, nil)
 	if err != nil {
@@ -576,7 +610,7 @@ func (s *ChangesService) GetContentType(changeID, revisionID, fileID string) (*R
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-reviewed
 func (s *ChangesService) SetReviewed(changeID, revisionID, fileID string) (*Response, error) {
-	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/reviewed", changeID, revisionID, fileID)
+	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/reviewed", changeID, revisionID, url.PathEscape(fileID))
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {

--- a/changes_revision_test.go
+++ b/changes_revision_test.go
@@ -1,0 +1,81 @@
+package gerrit_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/andygrunwald/go-gerrit"
+)
+
+func TestChangesService_ListFiles(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.String(), "/changes/123/revisions/456/files/?base=7"; got != want {
+			t.Errorf("request URL:\ngot:  %q\nwant: %q", got, want)
+		}
+		fmt.Fprint(w, `{
+		  "/COMMIT_MSG": {
+		    "status": "A",
+		    "lines_inserted": 7,
+		    "size_delta": 551,
+		    "size": 551
+		  },
+		  "gerrit-server/RefControl.java": {
+		    "lines_inserted": 5,
+		    "lines_deleted": 3,
+		    "size_delta": 98,
+		    "size": 23348
+		  }
+		}`)
+	}))
+	defer ts.Close()
+
+	client := newClient(t, ts)
+	got, _, err := client.Changes.ListFiles("123", "456", &gerrit.FilesOptions{
+		Base: "7",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]gerrit.FileInfo{
+		"/COMMIT_MSG": {
+			Status:        "A",
+			LinesInserted: 7,
+			SizeDelta:     551,
+			Size:          551,
+		},
+		"gerrit-server/RefControl.java": {
+			LinesInserted: 5,
+			LinesDeleted:  3,
+			SizeDelta:     98,
+			Size:          23348,
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("client.Changes.ListFiles:\ngot:  %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestChangesService_ListFilesReviewed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.String(), "/changes/123/revisions/456/files/?q=abc&reviewed=true"; got != want {
+			t.Errorf("request URL:\ngot:  %q\nwant: %q", got, want)
+		}
+		fmt.Fprint(w, `["/COMMIT_MSG","gerrit-server/RefControl.java"]`)
+	}))
+	defer ts.Close()
+
+	client := newClient(t, ts)
+	got, _, err := client.Changes.ListFilesReviewed("123", "456", &gerrit.FilesOptions{
+		Q: "abc",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"/COMMIT_MSG", "gerrit-server/RefControl.java"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("client.Changes.ListFilesReviewed:\ngot:  %q\nwant: %q", got, want)
+	}
+}

--- a/changes_test.go
+++ b/changes_test.go
@@ -36,7 +36,7 @@ func ExampleChangesService_QueryChanges() {
 }
 
 // Prior to fixing #18 this test would fail.
-func ExampleChangesService_QueryChangesWithSymbols() { // nolint: vet
+func ExampleChangesService_QueryChanges_withSymbols() {
 	instance := "https://android-review.googlesource.com/"
 	client, err := gerrit.NewClient(instance, nil)
 	if err != nil {


### PR DESCRIPTION
Modify ListFilesReviewed to return a slice of strings, rather than slice of FileInfos. This matches its actual behavior (according to documentation; I haven't tested against a real API because it requires auth).

Modify both ListFiles and ListFilesReviewed to return map/slice directly, rather than a pointer to one. There doesn't appear to be any value in returning a pointer, it just makes the API harder to use. Slice/map are already reference types.

Modify all endpoints to escape fileID parameter so it can be safely placed inside a URL path segment.

Make note of Base parameter being undocumented for ListFiles endpoints. However, it has been tested and it works (it's a very important parameter to support).

Add missing fields to ChangeMessageInfo, FileInfo.

Add tests for ListFiles, ListFilesReviewed.