### PR TITLE
Add Avatars field to AccountInfo.

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -17,6 +17,13 @@ type AccountInfo struct {
 	Name      string `json:"name,omitempty"`
 	Email     string `json:"email,omitempty"`
 	Username  string `json:"username,omitempty"`
+
+	// Avatars lists avatars of various sizes for the account.
+	// This field is only populated if the avatars plugin is enabled.
+	Avatars []struct {
+		URL    string `json:"url,omitempty"`
+		Height int    `json:"height,omitempty"`
+	} `json:"avatars,omitempty"`
 }
 
 // SSHKeyInfo entity contains information about an SSH key of a user.

--- a/config.go
+++ b/config.go
@@ -143,6 +143,7 @@ type ReceiveInfo struct {
 
 // PluginConfigInfo entity contains information about Gerrit extensions by plugins.
 type PluginConfigInfo struct {
+	// HasAvatars reports whether an avatar provider is registered.
 	HasAvatars bool `json:"has_avatars,omitempty"`
 }
 


### PR DESCRIPTION
This change implements support for the avatars plugin.
It appears to be available on many Gerrit instances hosted by Google.

Unfortunately, I have not been able to find any API documentation or
source for this augmentation of the AccountInfo entity. This change
is implemented based on looking at real responses from Google-hosted
Gerrit instances. E.g.:

	$ curl 'https://gerrit-review.googlesource.com/accounts/1010008'
	)]}'
	{
	  "_account_id": 1010008,
	  "name": "Example Example",
	  "email": "example@example.com",
	  "avatars": [
	    {
	      "url": "https://lh3.googleusercontent.com/-qjpKeQViQbI/AAAAAAAAAAI/AAAAAAAAAAA/_CVwpoi1Y8Y/s26-p/photo.jpg",
	      "height": 26
	    },
	    {
	      "url": "https://lh3.googleusercontent.com/-qjpKeQViQbI/AAAAAAAAAAI/AAAAAAAAAAA/_CVwpoi1Y8Y/s32-p/photo.jpg",
	      "height": 32
	    },
	    {
	      "url": "https://lh3.googleusercontent.com/-qjpKeQViQbI/AAAAAAAAAAI/AAAAAAAAAAA/_CVwpoi1Y8Y/s100-p/photo.jpg",
	      "height": 100
	    }
	  ]
	}

Resolves #51.