### PR TITLE
Make TravisCI build green again

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -1,7 +1,7 @@
 package gerrit
 
 import (
-	"crypto/md5" // nolint: gas
+	"crypto/md5" // nolint: gosec
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -117,7 +117,7 @@ func (s *AuthenticationService) digestAuthHeader(response *http.Response) (strin
 	uriHeader := authenticate["uri"]
 
 	// A1
-	h := md5.New() // nolint: gas
+	h := md5.New() // nolint: gosec
 	A1 := fmt.Sprintf("%s:%s:%s", s.name, realmHeader, s.secret)
 	if _, err := io.WriteString(h, A1); err != nil {
 		return "", err
@@ -125,7 +125,7 @@ func (s *AuthenticationService) digestAuthHeader(response *http.Response) (strin
 	HA1 := fmt.Sprintf("%x", h.Sum(nil))
 
 	// A2
-	h = md5.New() // nolint: gas
+	h = md5.New() // nolint: gosec
 	A2 := fmt.Sprintf("%s:%s", response.Request.Method, uriHeader)
 	if _, err := io.WriteString(h, A2); err != nil {
 		return "", err
@@ -141,7 +141,7 @@ func (s *AuthenticationService) digestAuthHeader(response *http.Response) (strin
 		bytes += n
 	}
 	cnonce := base64.StdEncoding.EncodeToString(k)
-	digest := md5.New() // nolint: gas
+	digest := md5.New() // nolint: gosec
 	if _, err := digest.Write([]byte(strings.Join([]string{HA1, nonceHeader, "00000001", cnonce, qopHeader, HA2}, ":"))); err != nil {
 		return "", err
 	}

--- a/changes.go
+++ b/changes.go
@@ -781,17 +781,16 @@ func (s *ChangesService) change(tail string, changeID string, input interface{})
 	v := new(ChangeInfo)
 	resp, err := s.client.Do(req, v)
 	if err != nil {
-		return v, resp, err
+		return nil, resp, err
 	}
 	if resp.StatusCode == http.StatusConflict {
-		var body []byte
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return v, resp, err
 		}
-		err = errors.New(string(body[:]))
+		return v, resp, errors.New(string(body[:]))
 	}
-	return v, resp, err
+	return v, resp, nil
 }
 
 // SubmitChange submits a change.

--- a/changes.go
+++ b/changes.go
@@ -780,8 +780,15 @@ func (s *ChangesService) change(tail string, changeID string, input interface{})
 
 	v := new(ChangeInfo)
 	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return v, resp, err
+	}
 	if resp.StatusCode == http.StatusConflict {
-		body, _ := ioutil.ReadAll(resp.Body)
+		var body []byte
+		body, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return v, resp, err
+		}
 		err = errors.New(string(body[:]))
 	}
 	return v, resp, err

--- a/changes.go
+++ b/changes.go
@@ -258,11 +258,11 @@ type RobotCommentInput struct {
 	CommentInput
 
 	// The ID of the robot that generated this comment.
-	RobotId string `json:"robot_id"`
+	RobotID string `json:"robot_id"`
 	// An ID of the run of the robot.
-	RobotRunId string `json:"robot_run_id"`
+	RobotRunID string `json:"robot_run_id"`
 	// URL to more information.
-	Url string `json:"url,omitempty"`
+	URL string `json:"url,omitempty"`
 	// Robot specific properties as map that maps arbitrary keys to values.
 	Properties *map[string]*string `json:"properties,omitempty"`
 	// Suggested fixes for this robot comment as a list of FixSuggestionInfo
@@ -277,11 +277,11 @@ type RobotCommentInfo struct {
 	CommentInfo
 
 	// The ID of the robot that generated this comment.
-	RobotId string `json:"robot_id"`
+	RobotID string `json:"robot_id"`
 	// An ID of the run of the robot.
-	RobotRunId string `json:"robot_run_id"`
+	RobotRunID string `json:"robot_run_id"`
 	// URL to more information.
-	Url string `json:"url,omitempty"`
+	URL string `json:"url,omitempty"`
 	// Robot specific properties as map that maps arbitrary keys to values.
 	Properties map[string]string `json:"properties,omitempty"`
 	// Suggested fixes for this robot comment as a list of FixSuggestionInfo
@@ -294,7 +294,7 @@ type RobotCommentInfo struct {
 type FixSuggestionInfo struct {
 	// The UUID of the suggested fix. It will be generated automatically and
 	// hence will be ignored if it’s set for input objects.
-	FixId string `json:"fix_id"`
+	FixID string `json:"fix_id"`
 	// A description of the suggested fix.
 	Description string `json:"description"`
 	// A list of FixReplacementInfo entities indicating how the content of one or


### PR DESCRIPTION
This PR makes the TravisCI build green again. In detail

* Rename struct fields to Go naming convention (golint)
* Renamed the gometalinter `gas` to `gosec`
* Fixed the handing of an unhandled error

One important note: The renaming of struct fields is a breaking change. It was introduced in https://github.com/andygrunwald/go-gerrit/pull/60. @achew22 would be nice if you can check this as well, because it might break your code.