### PR TITLE
drop support for Go 1.9, add Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: go
 sudo: false
 
 go:
+  - "1.12.x"
   - "1.11.x"
   - "1.10.x"
-  - "1.9.x"
 
 before_install:
   - make deps

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt vet check-vendor lint check clean test build
+.PHONY: fmt vet lint check test
 PACKAGES = $(shell go list ./...)
 PACKAGE_DIRS = $(shell go list -f '{{ .Dir }}' ./...)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ go-gerrit is a [Go(lang)](https://golang.org/) client library for accessing the 
 
 ## Installation
 
-go-gerrit requires Go version 1.8 or greater.
+go-gerrit requires Go version 1.10 or greater.
 
 It is go gettable ...
 


### PR DESCRIPTION
Update README to mention current minimum Go version.

Remove non-existent .PHONY rules from Makefile.

This change fixes CI, which is currently [broken](https://travis-ci.org/andygrunwald/go-gerrit/builds/549446647).

/cc @andygrunwald