### PR TITLE
fix: fix json-tag of change-info-number

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -361,7 +361,7 @@ type ChangeInfo struct {
 	Mergeable          bool                     `json:"mergeable,omitempty"`
 	Insertions         int                      `json:"insertions"`
 	Deletions          int                      `json:"deletions"`
-	Number             int                      `json:"_number"`
+	Number             int                      `json:"number"`
 	Owner              AccountInfo              `json:"owner"`
 	Actions            map[string]ActionInfo    `json:"actions,omitempty"`
 	Labels             map[string]LabelInfo     `json:"labels,omitempty"`

--- a/types_test.go
+++ b/types_test.go
@@ -16,7 +16,7 @@ func TestTimestamp(t *testing.T) {
 	"created": "2018-05-04 17:24:39.000000000",
 	"updated": "0001-01-01 00:00:00.000000000",
 	"submitted": "2018-05-04 18:01:10.000000000",
-	"_number": 111517
+	"number": 111517
 }
 `
 	type ChangeInfo struct {
@@ -25,7 +25,7 @@ func TestTimestamp(t *testing.T) {
 		Updated   gerrit.Timestamp  `json:"updated"`
 		Submitted *gerrit.Timestamp `json:"submitted,omitempty"`
 		Omitted   *gerrit.Timestamp `json:"omitted,omitempty"`
-		Number    int               `json:"_number"`
+		Number    int               `json:"number"`
 	}
 	ci := ChangeInfo{
 		Subject:   "net/http: write status code in Redirect when Content-Type header set",


### PR DESCRIPTION
gerrit event document: https://gerrit-review.googlesource.com/Documentation/cmd-stream-events.html#_patchset_created

from this doc, change number json-tag is `number`, not `_number`