### PR TITLE
add support for Change API's "Set Commit Message" endpoint

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -51,6 +51,13 @@ type ApprovalInfo struct {
 	Date  string `json:"date,omitempty"`
 }
 
+// CommitMessageInput entity contains information for changing the commit message of a change.
+type CommitMessageInput struct {
+	Message       string       `json:"message,omitempty"`
+	Notify        string       `json:"notify,omitempty"`
+	NotifyDetails []NotifyInfo `json:"notify_details"`
+}
+
 // ChangeEditInput entity contains information for restoring a path within change edit.
 type ChangeEditInput struct {
 	RestorePath string `json:"restore_path,omitempty"`
@@ -686,6 +693,23 @@ func (s *ChangesService) CreateChange(input *ChangeInfo) (*ChangeInfo, *Response
 	}
 
 	return v, resp, err
+}
+
+// SetCommitMessage creates a new patch set with a new commit message.
+// The new commit message must be provided in the request body inside a CommitMessageInput entity.
+// If a Change-Id footer is specified, it must match the current Change-Id footer.
+// If the Change-Id footer is absent, the current Change-Id is added to the message.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-message
+func (s *ChangesService) SetCommitMessage(changeID string, input *CommitMessageInput) (*Response, error) {
+	u := fmt.Sprintf("changes/%s/message", changeID)
+
+	req, err := s.client.NewRequest("PUT", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }
 
 // SetTopic sets the topic of a change.

--- a/changes_test.go
+++ b/changes_test.go
@@ -294,3 +294,52 @@ func TestChangesService_RevertChange_Conflict(t *testing.T) {
 		t.Error("Expected 409 code")
 	}
 }
+
+func TestChangesService_SetCommitMessage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes/123/message" {
+			t.Errorf("%s != /changes/123/message", r.URL.Path)
+		}
+		if r.Method != "PUT" {
+			t.Error("Method != PUT")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	cm := &gerrit.CommitMessageInput{Message: "New commit message"}
+	_, err = client.Changes.SetCommitMessage("123", cm)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestChangesService_SetCommitMessage_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes/123/message" {
+			t.Errorf("%s != /changes/123/message", r.URL.Path)
+		}
+		if r.Method != "PUT" {
+			t.Error("Method != PUT")
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client, err := gerrit.NewClient(ts.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	cm := &gerrit.CommitMessageInput{Message: "New commit message"}
+	resp, err := client.Changes.SetCommitMessage("123", cm)
+	if err == nil {
+		t.Error("Expected error, instead nil")
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Error("Expected 404 code")
+	}
+}


### PR DESCRIPTION
Thanks for your excellent Gerrit API client! I wish Google offered something like this.