### PR TITLE
omitempty for AbandonInput.Notify and AbandonInput.NotifyDetails fields

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -40,8 +40,8 @@ type NotifyInfo struct {
 // AbandonInput entity contains information for abandoning a change.
 type AbandonInput struct {
 	Message       string       `json:"message,omitempty"`
-	Notify        string       `json:"notify"`
-	NotifyDetails []NotifyInfo `json:"notify_details"`
+	Notify        string       `json:"notify,omitempty"`
+	NotifyDetails []NotifyInfo `json:"notify_details,omitempty"`
 }
 
 // ApprovalInfo entity contains information about an approval from a user for a label on a change.


### PR DESCRIPTION
Set `omitempty` for `AbandonInput.Notify` and `AbandonInput.NotifyDetails` fields.

The reason for this change is that if `NotifyDetails` is not set, `notify_details` will be unmarshalled as `nill` in the json string, which isn't allowed by the Gerrit server and will result in a `400 Bad Request` response.