### PR TITLE
changes: rename Changes.DeleteDraftChange to DeleteChange

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -778,11 +778,14 @@ func (s *ChangesService) DeleteTopic(changeID string) (*Response, error) {
 	return s.client.DeleteRequest(u, nil)
 }
 
-// DeleteDraftChange deletes a draft change.
+// DeleteChange deletes a new or abandoned change
 //
-// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-draft-change
-func (s *ChangesService) DeleteDraftChange(changeID string) (*Response, error) {
-	u := fmt.Sprintf("changes/%s", changeID)
+// New or abandoned changes can be deleted by their owner if the user is granted the Delete Own Changes
+// permission, otherwise only by administrators.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-change
+func (s *ChangesService) DeleteChange(changeID string) (*Response, error) {
+	u := fmt.Sprintf("changes/%s/", changeID)
 	return s.client.DeleteRequest(u, nil)
 }
 

--- a/changes.go
+++ b/changes.go
@@ -785,7 +785,7 @@ func (s *ChangesService) DeleteTopic(changeID string) (*Response, error) {
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-change
 func (s *ChangesService) DeleteChange(changeID string) (*Response, error) {
-	u := fmt.Sprintf("changes/%s/", changeID)
+	u := fmt.Sprintf("changes/%s", changeID)
 	return s.client.DeleteRequest(u, nil)
 }
 


### PR DESCRIPTION
It was reported in #77 that the delete-draft-change API referenced in
the docs no longer exists. As suggested in the issue, just rename to
to Changes.DeleteChange.