### PR TITLE
changes: fill in the rest of Changes.ChangeInput

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -371,14 +371,21 @@ type DiffIntralineInfo [][2]int
 //
 // Docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#change-input
 type ChangeInput struct {
-	Project string `json:"project"`
-	Branch  string `json:"branch"`
-	Subject string `json:"subject"`
-	Topic   string `json:"topic,omitempty"`
-	Status  string `json:"status,omitempty"`
-
-	// Attention: Fields are missing.
-	// TODO Add the full list of attributes from https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#change-input
+	Project           string                 `json:"project"`
+	Branch            string                 `json:"branch"`
+	Subject           string                 `json:"subject"`
+	Topic             string                 `json:"topic,omitempty"`
+	Status            string                 `json:"status,omitempty"`
+	IsPrivate         bool                   `json:"is_private,omitempty"`
+	WorkInProgress    bool                   `json:"work_in_progress,omitempty"`
+	BaseChange        string                 `json:"base_change,omitempty"`
+	BaseCommit        string                 `json:"base_commit,omitempty"`
+	NewBranch         bool                   `json:"new_branch,omitempty"`
+	ValidationOptions map[string]interface{} `json:"validation_options,omitempty"`
+	Merge             *MergeInput            `json:"merge,omitempty"`
+	Author            *AccountInput          `json:"author,omitempty"`
+	Notify            string                 `json:"notify,omitempty"`
+	NotifyDetails     string                 `json:"notify_details,omitempty"`
 }
 
 // ChangeInfo entity contains information about a change.
@@ -448,6 +455,16 @@ type LabelInfo struct {
 	// Fields set by DETAILED_LABELS
 	All    []ApprovalInfo    `json:"all,omitempty"`
 	Values map[string]string `json:"values,omitempty"`
+}
+
+// The MergeInput entity contains information about the merge
+//
+// Docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#merge-input
+type MergeInput struct {
+	Source         string `json:"source"`
+	SourceBranch   string `json:"source_branch,omitempty"`
+	Strategy       string `json:"strategy,omitempty"`
+	AllowConflicts bool   `json:"allow_conflicts,omitempty"`
 }
 
 // RevisionInfo entity contains information about a patch set.


### PR DESCRIPTION
The ChangeInput type was recently added with just the bare-bones
fields in place. This commit adds the rest of the fields per the
current gerrit documentation.

Updated TestChangesService_CreateChange to have stronger assertions
about empty values (recursively checks nested structures), and added
test cases specific to exercise ChangeInput.Merge and
ChangeInput.Author.

This change is a result of the discussion on PR #96.