### PR TITLE
add: project commits included in

### DIFF
--- a/projects_commit.go
+++ b/projects_commit.go
@@ -26,6 +26,25 @@ func (s *ProjectsService) GetCommit(projectName, commitID string) (*CommitInfo, 
 	return v, resp, err
 }
 
+// GetIncludeIn Retrieves the branches and tags in which a change is included.
+// Branches that are not visible to the calling user according to the project’s read permissions are filtered out from the result.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-included-in
+func (s *ProjectsService) GetIncludeIn(projectName, commitID string) (*IncludedInInfo, *Response, error) {
+	u := fmt.Sprintf("projects/%s/commits/%s/in", url.QueryEscape((projectName)), commitID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	v := new(IncludedInInfo)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
 // GetCommitContent gets the content of a file from a certain commit.
 // The content is returned as base64 encoded string.
 //

--- a/projects_commit_test.go
+++ b/projects_commit_test.go
@@ -1,0 +1,39 @@
+package gerrit_test
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/andygrunwald/go-gerrit"
+)
+
+// +func (s *ProjectsService) GetIncludeIn(projectName, commitID string) (*IncludedInInfo, *Response, error){
+func TestProjectsService_GetIncludeIn(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/projects/swift/commits/a8a477efffbbf3b44169bb9a1d3a334cbbd9aa96/in", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `)]}'`+"\n"+`{"branches": ["master"],"tags": ["1.1.0"]}`)
+	})
+
+	includedInInfo, _, err := testClient.Projects.GetIncludeIn("swift", "a8a477efffbbf3b44169bb9a1d3a334cbbd9aa96")
+	if err != nil {
+		t.Errorf("Projects.GetIncludeIn returned error: %v", err)
+	}
+
+	want := &gerrit.IncludedInInfo{
+		Branches: []string{
+			"master",
+		},
+		Tags: []string{
+			"1.1.0",
+		},
+	}
+
+	if !reflect.DeepEqual(includedInInfo, want) {
+		t.Errorf("Projects.GetIncludeIn returned %+v, want %+v", includedInInfo, want)
+	}
+}


### PR DESCRIPTION
GetIncludeIn Retrieves the branches and tags in which a change is included.

Branches that are not visible to the calling user according to the project’s read permissions are filtered out from the result.

Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-included-in