### PR TITLE
fix parameter capitalisation in `ProjectBaseOptions` struct

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -177,7 +177,7 @@ type ProjectBaseOptions struct {
 	Limit int `url:"n,omitempty"`
 
 	// Skip the given number of branches from the beginning of the list.
-	Skip string `url:"s,omitempty"`
+	Skip string `url:"S,omitempty"`
 }
 
 // ProjectOptions specifies the parameters to the ProjectsService.ListProjects.


### PR DESCRIPTION
close: #148 