### PR TITLE
Add golang context support

### DIFF
--- a/access.go
+++ b/access.go
@@ -1,5 +1,7 @@
 package gerrit
 
+import "context"
+
 // AccessService contains Access Right related REST endpoints
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-access.html
@@ -63,7 +65,7 @@ type ListAccessRightsOptions struct {
 // The entries in the map are sorted by project name.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-access.html#list-access
-func (s *AccessService) ListAccessRights(opt *ListAccessRightsOptions) (*map[string]ProjectAccessInfo, *Response, error) {
+func (s *AccessService) ListAccessRights(ctx context.Context, opt *ListAccessRightsOptions) (*map[string]ProjectAccessInfo, *Response, error) {
 	u := "access/"
 
 	u, err := addOptions(u, opt)
@@ -72,6 +74,6 @@ func (s *AccessService) ListAccessRights(opt *ListAccessRightsOptions) (*map[str
 	}
 
 	v := new(map[string]ProjectAccessInfo)
-	resp, err := s.client.Call("GET", u, nil, v)
+	resp, err := s.client.Call(ctx, "GET", u, nil, v)
 	return v, resp, err
 }

--- a/access_test.go
+++ b/access_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -25,7 +26,7 @@ func TestAccessService_ListAccessRights(t *testing.T) {
 	opt := &gerrit.ListAccessRightsOptions{
 		Project: []string{"go"},
 	}
-	access, _, err := testClient.Access.ListAccessRights(opt)
+	access, _, err := testClient.Access.ListAccessRights(context.Background(), opt)
 	if err != nil {
 		t.Errorf("Access.ListAccessRights returned error: %v", err)
 	}
@@ -60,7 +61,7 @@ func TestAccessService_ListAccessRights_WithoutOpts(t *testing.T) {
 		fmt.Fprint(w, `)]}'`+"\n"+`{}`)
 	})
 
-	access, _, err := testClient.Access.ListAccessRights(nil)
+	access, _, err := testClient.Access.ListAccessRights(context.Background(), nil)
 	if err != nil {
 		t.Errorf("Access.ListAccessRights returned error: %v", err)
 	}

--- a/accounts.go
+++ b/accounts.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -262,7 +263,7 @@ type CapabilityOptions struct {
 // The n parameter can be used to limit the returned results.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#query-accounts
-func (s *AccountsService) QueryAccounts(opt *QueryAccountOptions) (*[]AccountInfo, *Response, error) {
+func (s *AccountsService) QueryAccounts(ctx context.Context, opt *QueryAccountOptions) (*[]AccountInfo, *Response, error) {
 	u := "accounts/"
 
 	u, err := addOptions(u, opt)
@@ -270,7 +271,7 @@ func (s *AccountsService) QueryAccounts(opt *QueryAccountOptions) (*[]AccountInf
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -288,10 +289,10 @@ func (s *AccountsService) QueryAccounts(opt *QueryAccountOptions) (*[]AccountInf
 // If account is "self" the current authenticated account will be returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-account
-func (s *AccountsService) GetAccount(account string) (*AccountInfo, *Response, error) {
+func (s *AccountsService) GetAccount(ctx context.Context, account string) (*AccountInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s", account)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -308,10 +309,10 @@ func (s *AccountsService) GetAccount(account string) (*AccountInfo, *Response, e
 // GetAccountDetails retrieves the details of an account.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-detail
-func (s *AccountsService) GetAccountDetails(accountID string) (*AccountDetailInfo, *Response, error) {
+func (s *AccountsService) GetAccountDetails(ctx context.Context, accountID string) (*AccountDetailInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/detail", accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -331,10 +332,10 @@ func (s *AccountsService) GetAccountDetails(accountID string) (*AccountDetailInf
 // Users that have Modify Account can request external ids that belong to other accounts.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-account-external-ids
-func (s *AccountsService) GetAccountExternalIDs(accountID string) (*[]AccountExternalIdInfo, *Response, error) {
+func (s *AccountsService) GetAccountExternalIDs(ctx context.Context, accountID string) (*[]AccountExternalIdInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/external.ids", accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -351,34 +352,34 @@ func (s *AccountsService) GetAccountExternalIDs(accountID string) (*[]AccountExt
 // GetAccountName retrieves the full name of an account.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-account-name
-func (s *AccountsService) GetAccountName(accountID string) (string, *Response, error) {
+func (s *AccountsService) GetAccountName(ctx context.Context, accountID string) (string, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/name", accountID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // GetUsername retrieves the username of an account.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-username
-func (s *AccountsService) GetUsername(accountID string) (string, *Response, error) {
+func (s *AccountsService) GetUsername(ctx context.Context, accountID string) (string, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/username", accountID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // GetHTTPPassword retrieves the HTTP password of an account.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-http-password
-func (s *AccountsService) GetHTTPPassword(accountID string) (string, *Response, error) {
+func (s *AccountsService) GetHTTPPassword(ctx context.Context, accountID string) (string, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/password.http", accountID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // ListAccountEmails returns the email addresses that are configured for the specified user.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#list-account-emails
-func (s *AccountsService) ListAccountEmails(accountID string) (*[]EmailInfo, *Response, error) {
+func (s *AccountsService) ListAccountEmails(ctx context.Context, accountID string) (*[]EmailInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/emails", accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -395,10 +396,10 @@ func (s *AccountsService) ListAccountEmails(accountID string) (*[]EmailInfo, *Re
 // GetAccountEmail retrieves an email address of a user.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-account-email
-func (s *AccountsService) GetAccountEmail(accountID, emailID string) (*EmailInfo, *Response, error) {
+func (s *AccountsService) GetAccountEmail(ctx context.Context, accountID, emailID string) (*EmailInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/emails/%s", accountID, emailID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -415,10 +416,10 @@ func (s *AccountsService) GetAccountEmail(accountID, emailID string) (*EmailInfo
 // ListSSHKeys returns the SSH keys of an account.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#list-ssh-keys
-func (s *AccountsService) ListSSHKeys(accountID string) (*[]SSHKeyInfo, *Response, error) {
+func (s *AccountsService) ListSSHKeys(ctx context.Context, accountID string) (*[]SSHKeyInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/sshkeys", accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -435,10 +436,10 @@ func (s *AccountsService) ListSSHKeys(accountID string) (*[]SSHKeyInfo, *Respons
 // GetSSHKey retrieves an SSH key of a user.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-ssh-key
-func (s *AccountsService) GetSSHKey(accountID, sshKeyID string) (*SSHKeyInfo, *Response, error) {
+func (s *AccountsService) GetSSHKey(ctx context.Context, accountID, sshKeyID string) (*SSHKeyInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/sshkeys/%s", accountID, sshKeyID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -455,10 +456,10 @@ func (s *AccountsService) GetSSHKey(accountID, sshKeyID string) (*SSHKeyInfo, *R
 // ListGPGKeys returns the GPG keys of an account.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#list-gpg-keys
-func (s *AccountsService) ListGPGKeys(accountID string) (*map[string]GpgKeyInfo, *Response, error) {
+func (s *AccountsService) ListGPGKeys(ctx context.Context, accountID string) (*map[string]GpgKeyInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/gpgkeys", accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -475,10 +476,10 @@ func (s *AccountsService) ListGPGKeys(accountID string) (*map[string]GpgKeyInfo,
 // GetGPGKey retrieves a GPG key of a user.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-gpg-key
-func (s *AccountsService) GetGPGKey(accountID, gpgKeyID string) (*GpgKeyInfo, *Response, error) {
+func (s *AccountsService) GetGPGKey(ctx context.Context, accountID, gpgKeyID string) (*GpgKeyInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/gpgkeys/%s", accountID, gpgKeyID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -497,7 +498,7 @@ func (s *AccountsService) GetGPGKey(accountID, gpgKeyID string) (*GpgKeyInfo, *R
 // This can be used by UI tools to discover if administrative features are available to the caller, so they can hide (or show) relevant UI actions.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#list-account-capabilities
-func (s *AccountsService) ListAccountCapabilities(accountID string, opt *CapabilityOptions) (*AccountCapabilityInfo, *Response, error) {
+func (s *AccountsService) ListAccountCapabilities(ctx context.Context, accountID string, opt *CapabilityOptions) (*AccountCapabilityInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/capabilities", accountID)
 
 	u, err := addOptions(u, opt)
@@ -505,7 +506,7 @@ func (s *AccountsService) ListAccountCapabilities(accountID string, opt *Capabil
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -522,10 +523,10 @@ func (s *AccountsService) ListAccountCapabilities(accountID string, opt *Capabil
 // ListGroups lists all groups that contain the specified user as a member.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#list-groups
-func (s *AccountsService) ListGroups(accountID string) (*[]GroupInfo, *Response, error) {
+func (s *AccountsService) ListGroups(ctx context.Context, accountID string) (*[]GroupInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/groups", accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -542,10 +543,10 @@ func (s *AccountsService) ListGroups(accountID string) (*[]GroupInfo, *Response,
 // GetUserPreferences retrieves the user’s preferences.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-user-preferences
-func (s *AccountsService) GetUserPreferences(accountID string) (*PreferencesInfo, *Response, error) {
+func (s *AccountsService) GetUserPreferences(ctx context.Context, accountID string) (*PreferencesInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/preferences", accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -562,10 +563,10 @@ func (s *AccountsService) GetUserPreferences(accountID string) (*PreferencesInfo
 // GetDiffPreferences retrieves the diff preferences of a user.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-diff-preferences
-func (s *AccountsService) GetDiffPreferences(accountID string) (*DiffPreferencesInfo, *Response, error) {
+func (s *AccountsService) GetDiffPreferences(ctx context.Context, accountID string) (*DiffPreferencesInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/preferences.diff", accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -583,10 +584,10 @@ func (s *AccountsService) GetDiffPreferences(accountID string) (*DiffPreferences
 // This URL endpoint is functionally identical to the changes query GET /changes/?q=is:starred.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-starred-changes
-func (s *AccountsService) GetStarredChanges(accountID string) (*[]ChangeInfo, *Response, error) {
+func (s *AccountsService) GetStarredChanges(ctx context.Context, accountID string) (*[]ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/starred.changes", accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -605,7 +606,7 @@ func (s *AccountsService) GetStarredChanges(accountID string) (*[]ChangeInfo, *R
 // Returns a list of matching AccountInfo entities.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#query-account
-func (s *AccountsService) SuggestAccount(opt *QueryAccountOptions) (*[]AccountInfo, *Response, error) {
+func (s *AccountsService) SuggestAccount(ctx context.Context, opt *QueryAccountOptions) (*[]AccountInfo, *Response, error) {
 	u := "accounts/"
 
 	u, err := addOptions(u, opt)
@@ -613,7 +614,7 @@ func (s *AccountsService) SuggestAccount(opt *QueryAccountOptions) (*[]AccountIn
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -631,10 +632,10 @@ func (s *AccountsService) SuggestAccount(opt *QueryAccountOptions) (*[]AccountIn
 // In the request body additional data for the account can be provided as AccountInput.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#create-account
-func (s *AccountsService) CreateAccount(username string, input *AccountInput) (*AccountInfo, *Response, error) {
+func (s *AccountsService) CreateAccount(ctx context.Context, username string, input *AccountInput) (*AccountInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s", username)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -657,12 +658,12 @@ func (s *AccountsService) CreateAccount(username string, input *AccountInput) (*
 // In this case the request is rejected with “405 Method Not Allowed”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#set-account-name
-func (s *AccountsService) SetAccountName(accountID string, input *AccountNameInput) (*string, *Response, error) {
+func (s *AccountsService) SetAccountName(ctx context.Context, accountID string, input *AccountNameInput) (*string, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/name", accountID)
 
 	// TODO Use here the getStringResponseWithoutOptions (for PUT requests)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -679,50 +680,50 @@ func (s *AccountsService) SetAccountName(accountID string, input *AccountNameInp
 // DeleteAccountName deletes the name of an account.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#delete-account-name
-func (s *AccountsService) DeleteAccountName(accountID string) (*Response, error) {
+func (s *AccountsService) DeleteAccountName(ctx context.Context, accountID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/name", accountID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteActive sets the account state to inactive.
 // If the account was already inactive the response is “404 Not Found”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#delete-active
-func (s *AccountsService) DeleteActive(accountID string) (*Response, error) {
+func (s *AccountsService) DeleteActive(ctx context.Context, accountID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/active", accountID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteHTTPPassword deletes the HTTP password of an account.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#delete-http-password
-func (s *AccountsService) DeleteHTTPPassword(accountID string) (*Response, error) {
+func (s *AccountsService) DeleteHTTPPassword(ctx context.Context, accountID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/password.http", accountID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteAccountEmail deletes an email address of an account.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#delete-account-email
-func (s *AccountsService) DeleteAccountEmail(accountID, emailID string) (*Response, error) {
+func (s *AccountsService) DeleteAccountEmail(ctx context.Context, accountID, emailID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/emails/%s", accountID, emailID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteSSHKey deletes an SSH key of a user.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#delete-ssh-key
-func (s *AccountsService) DeleteSSHKey(accountID, sshKeyID string) (*Response, error) {
+func (s *AccountsService) DeleteSSHKey(ctx context.Context, accountID, sshKeyID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/sshkeys/%s", accountID, sshKeyID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteGPGKey deletes a GPG key of a user.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#delete-gpg-key
-func (s *AccountsService) DeleteGPGKey(accountID, gpgKeyID string) (*Response, error) {
+func (s *AccountsService) DeleteGPGKey(ctx context.Context, accountID, gpgKeyID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/gpgkeys/%s", accountID, gpgKeyID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // SetUsername sets a new username.
@@ -733,10 +734,10 @@ func (s *AccountsService) DeleteGPGKey(accountID, gpgKeyID string) (*Response, e
 // As response the new username is returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#set-username
-func (s *AccountsService) SetUsername(accountID string, input *UsernameInput) (*string, *Response, error) {
+func (s *AccountsService) SetUsername(ctx context.Context, accountID string, input *UsernameInput) (*string, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/username", accountID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -756,9 +757,9 @@ func (s *AccountsService) SetUsername(accountID string, input *UsernameInput) (*
 // If the account is inactive the response is “204 No Content”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-active
-func (s *AccountsService) GetActive(accountID string) (string, *Response, error) {
+func (s *AccountsService) GetActive(ctx context.Context, accountID string) (string, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/active", accountID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // SetActive sets the account state to active.
@@ -766,10 +767,10 @@ func (s *AccountsService) GetActive(accountID string) (string, *Response, error)
 // If the account was already active the response is “200 OK”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#set-active
-func (s *AccountsService) SetActive(accountID string) (*Response, error) {
+func (s *AccountsService) SetActive(ctx context.Context, accountID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/active", accountID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -783,10 +784,10 @@ func (s *AccountsService) SetActive(accountID string) (*Response, error) {
 // If the HTTP password was deleted the response is “204 No Content”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#set-http-password
-func (s *AccountsService) SetHTTPPassword(accountID string, input *HTTPPasswordInput) (*string, *Response, error) {
+func (s *AccountsService) SetHTTPPassword(ctx context.Context, accountID string, input *HTTPPasswordInput) (*string, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/password.http", accountID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -809,10 +810,10 @@ func (s *AccountsService) SetHTTPPassword(accountID string, input *HTTPPasswordI
 // As response the new email address is returned as EmailInfo entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#create-account-email
-func (s *AccountsService) CreateAccountEmail(accountID, emailID string, input *EmailInput) (*EmailInfo, *Response, error) {
+func (s *AccountsService) CreateAccountEmail(ctx context.Context, accountID, emailID string, input *EmailInput) (*EmailInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/emails/%s", accountID, emailID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -831,10 +832,10 @@ func (s *AccountsService) CreateAccountEmail(accountID, emailID string, input *E
 // If the email address was already the preferred email address of the account the response is “200 OK”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#set-preferred-email
-func (s *AccountsService) SetPreferredEmail(accountID, emailID string) (*Response, error) {
+func (s *AccountsService) SetPreferredEmail(ctx context.Context, accountID, emailID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/emails/%s/preferred", accountID, emailID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -844,9 +845,9 @@ func (s *AccountsService) SetPreferredEmail(accountID, emailID string) (*Respons
 // GetAvatarChangeURL retrieves the URL where the user can change the avatar image.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#get-avatar-change-url
-func (s *AccountsService) GetAvatarChangeURL(accountID string) (string, *Response, error) {
+func (s *AccountsService) GetAvatarChangeURL(ctx context.Context, accountID string) (string, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/avatar.change.url", accountID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // AddGPGKeys Add or delete one or more GPG keys for a user.
@@ -856,10 +857,10 @@ func (s *AccountsService) GetAvatarChangeURL(accountID string) (string, *Respons
 // As a response, the modified GPG keys are returned as a map of GpgKeyInfo entities, keyed by ID. Deleted keys are represented by an empty object.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#add-delete-gpg-keys
-func (s *AccountsService) AddGPGKeys(accountID string, input *GpgKeysInput) (*map[string]GpgKeyInfo, *Response, error) {
+func (s *AccountsService) AddGPGKeys(ctx context.Context, accountID string, input *GpgKeysInput) (*map[string]GpgKeyInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/gpgkeys", accountID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -879,9 +880,9 @@ func (s *AccountsService) AddGPGKeys(accountID string, input *GpgKeysInput) (*ma
 // If the user doesn’t have the global capability the response is “404 Not Found”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#check-account-capability
-func (s *AccountsService) CheckAccountCapability(accountID, capabilityID string) (string, *Response, error) {
+func (s *AccountsService) CheckAccountCapability(ctx context.Context, accountID, capabilityID string) (string, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/capabilities/%s", accountID, capabilityID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // SetUserPreferences sets the user’s preferences.
@@ -890,10 +891,10 @@ func (s *AccountsService) CheckAccountCapability(accountID, capabilityID string)
 // As result the new preferences of the user are returned as a PreferencesInfo entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#set-user-preferences
-func (s *AccountsService) SetUserPreferences(accountID string, input *PreferencesInput) (*PreferencesInfo, *Response, error) {
+func (s *AccountsService) SetUserPreferences(ctx context.Context, accountID string, input *PreferencesInput) (*PreferencesInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/preferences", accountID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -913,10 +914,10 @@ func (s *AccountsService) SetUserPreferences(accountID string, input *Preference
 // As result the new diff preferences of the user are returned as a DiffPreferencesInfo entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#set-diff-preferences
-func (s *AccountsService) SetDiffPreferences(accountID string, input *DiffPreferencesInput) (*DiffPreferencesInfo, *Response, error) {
+func (s *AccountsService) SetDiffPreferences(ctx context.Context, accountID string, input *DiffPreferencesInput) (*DiffPreferencesInfo, *Response, error) {
 	u := fmt.Sprintf("accounts/%s/preferences.diff", accountID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -934,10 +935,10 @@ func (s *AccountsService) SetDiffPreferences(accountID string, input *DiffPrefer
 // Starred changes are returned for the search query is:starred or starredby:USER and automatically notify the user whenever updates are made to the change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#star-change
-func (s *AccountsService) StarChange(accountID, changeID string) (*Response, error) {
+func (s *AccountsService) StarChange(ctx context.Context, accountID, changeID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/starred.changes/%s", accountID, changeID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -949,9 +950,9 @@ func (s *AccountsService) StarChange(accountID, changeID string) (*Response, err
 // Removes the starred flag, stopping notifications.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#unstar-change
-func (s *AccountsService) UnstarChange(accountID, changeID string) (*Response, error) {
+func (s *AccountsService) UnstarChange(ctx context.Context, accountID, changeID string) (*Response, error) {
 	u := fmt.Sprintf("accounts/%s/starred.changes/%s", accountID, changeID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 /*

--- a/changes.go
+++ b/changes.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -563,7 +564,7 @@ type ChangeOptions struct {
 // The change output is sorted by the last update time, most recently updated to oldest updated.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-changes
-func (s *ChangesService) QueryChanges(opt *QueryChangeOptions) (*[]ChangeInfo, *Response, error) {
+func (s *ChangesService) QueryChanges(ctx context.Context, opt *QueryChangeOptions) (*[]ChangeInfo, *Response, error) {
 	u := "changes/"
 
 	u, err := addOptions(u, opt)
@@ -571,7 +572,7 @@ func (s *ChangesService) QueryChanges(opt *QueryChangeOptions) (*[]ChangeInfo, *
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -589,9 +590,9 @@ func (s *ChangesService) QueryChanges(opt *QueryChangeOptions) (*[]ChangeInfo, *
 // Additional fields can be obtained by adding o parameters, each option requires more database lookups and slows down the query response time to the client so they are generally disabled by default.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-change
-func (s *ChangesService) GetChange(changeID string, opt *ChangeOptions) (*ChangeInfo, *Response, error) {
+func (s *ChangesService) GetChange(ctx context.Context, changeID string, opt *ChangeOptions) (*ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s", changeID)
-	return s.getChangeInfoResponse(u, opt)
+	return s.getChangeInfoResponse(ctx, u, opt)
 }
 
 // GetChangeDetail retrieves a change with labels, detailed labels, detailed accounts, and messages.
@@ -601,19 +602,19 @@ func (s *ChangesService) GetChange(changeID string, opt *ChangeOptions) (*Change
 // The combined label vote is calculated in the following order (from highest to lowest): REJECTED > APPROVED > DISLIKED > RECOMMENDED.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-change-detail
-func (s *ChangesService) GetChangeDetail(changeID string, opt *ChangeOptions) (*ChangeInfo, *Response, error) {
+func (s *ChangesService) GetChangeDetail(ctx context.Context, changeID string, opt *ChangeOptions) (*ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/detail", changeID)
-	return s.getChangeInfoResponse(u, opt)
+	return s.getChangeInfoResponse(ctx, u, opt)
 }
 
 // getChangeInfoResponse retrieved a single ChangeInfo Response for a GET request
-func (s *ChangesService) getChangeInfoResponse(u string, opt *ChangeOptions) (*ChangeInfo, *Response, error) {
+func (s *ChangesService) getChangeInfoResponse(ctx context.Context, u string, opt *ChangeOptions) (*ChangeInfo, *Response, error) {
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -630,19 +631,19 @@ func (s *ChangesService) getChangeInfoResponse(u string, opt *ChangeOptions) (*C
 // GetTopic retrieves the topic of a change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-topic
-func (s *ChangesService) GetTopic(changeID string) (string, *Response, error) {
+func (s *ChangesService) GetTopic(ctx context.Context, changeID string) (string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/topic", changeID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // ChangesSubmittedTogether returns a list of all changes which are submitted when {submit} is called for this change, including the current change itself.
 // An empty list is returned if this change will be submitted by itself (no other changes).
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#submitted_together
-func (s *ChangesService) ChangesSubmittedTogether(changeID string) (*[]ChangeInfo, *Response, error) {
+func (s *ChangesService) ChangesSubmittedTogether(ctx context.Context, changeID string) (*[]ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/submitted_together", changeID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -659,10 +660,10 @@ func (s *ChangesService) ChangesSubmittedTogether(changeID string) (*[]ChangeInf
 // GetIncludedIn retrieves the branches and tags in which a change is included.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-included-in
-func (s *ChangesService) GetIncludedIn(changeID string) (*IncludedInInfo, *Response, error) {
+func (s *ChangesService) GetIncludedIn(ctx context.Context, changeID string) (*IncludedInInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/in", changeID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -681,9 +682,9 @@ func (s *ChangesService) GetIncludedIn(changeID string) (*IncludedInInfo, *Respo
 // Each comment has the patch_set and author fields set.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-change-comments
-func (s *ChangesService) ListChangeComments(changeID string) (*map[string][]CommentInfo, *Response, error) {
+func (s *ChangesService) ListChangeComments(ctx context.Context, changeID string) (*map[string][]CommentInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/comments", changeID)
-	return s.getCommentInfoMapResponse(u)
+	return s.getCommentInfoMapResponse(ctx, u)
 }
 
 // ListChangeDrafts lLists the draft comments of all revisions of the change that belong to the calling user.
@@ -691,14 +692,14 @@ func (s *ChangesService) ListChangeComments(changeID string) (*map[string][]Comm
 // Each comment has the patch_set field set, and no author.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-change-drafts
-func (s *ChangesService) ListChangeDrafts(changeID string) (*map[string][]CommentInfo, *Response, error) {
+func (s *ChangesService) ListChangeDrafts(ctx context.Context, changeID string) (*map[string][]CommentInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/drafts", changeID)
-	return s.getCommentInfoMapResponse(u)
+	return s.getCommentInfoMapResponse(ctx, u)
 }
 
 // getCommentInfoMapResponse retrieved a map of CommentInfo Response for a GET request
-func (s *ChangesService) getCommentInfoMapResponse(u string) (*map[string][]CommentInfo, *Response, error) {
-	req, err := s.client.NewRequest("GET", u, nil)
+func (s *ChangesService) getCommentInfoMapResponse(ctx context.Context, u string) (*map[string][]CommentInfo, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -717,14 +718,14 @@ func (s *ChangesService) getCommentInfoMapResponse(u string) (*map[string][]Comm
 // At least id, project, branch, and _number will be present.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#check-change
-func (s *ChangesService) CheckChange(changeID string) (*ChangeInfo, *Response, error) {
+func (s *ChangesService) CheckChange(ctx context.Context, changeID string) (*ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/check", changeID)
-	return s.getChangeInfoResponse(u, nil)
+	return s.getChangeInfoResponse(ctx, u, nil)
 }
 
 // getCommentInfoResponse retrieved a CommentInfo Response for a GET request
-func (s *ChangesService) getCommentInfoResponse(u string) (*CommentInfo, *Response, error) {
-	req, err := s.client.NewRequest("GET", u, nil)
+func (s *ChangesService) getCommentInfoResponse(ctx context.Context, u string) (*CommentInfo, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -739,8 +740,8 @@ func (s *ChangesService) getCommentInfoResponse(u string) (*CommentInfo, *Respon
 }
 
 // getCommentInfoMapSliceResponse retrieved a map with a slice of CommentInfo Response for a GET request
-func (s *ChangesService) getCommentInfoMapSliceResponse(u string) (*map[string][]CommentInfo, *Response, error) {
-	req, err := s.client.NewRequest("GET", u, nil)
+func (s *ChangesService) getCommentInfoMapSliceResponse(ctx context.Context, u string) (*map[string][]CommentInfo, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -766,10 +767,10 @@ func (s *ChangesService) getCommentInfoMapSliceResponse(u string) (*map[string][
 // As response a ChangeInfo entity is returned that describes the resulting change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#create-change
-func (s *ChangesService) CreateChange(input *ChangeInput) (*ChangeInfo, *Response, error) {
+func (s *ChangesService) CreateChange(ctx context.Context, input *ChangeInput) (*ChangeInfo, *Response, error) {
 	u := "changes/"
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -789,10 +790,10 @@ func (s *ChangesService) CreateChange(input *ChangeInput) (*ChangeInfo, *Respons
 // If the Change-Id footer is absent, the current Change-Id is added to the message.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-message
-func (s *ChangesService) SetCommitMessage(changeID string, input *CommitMessageInput) (*Response, error) {
+func (s *ChangesService) SetCommitMessage(ctx context.Context, changeID string, input *CommitMessageInput) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/message", changeID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, err
 	}
@@ -807,10 +808,10 @@ func (s *ChangesService) SetCommitMessage(changeID string, input *CommitMessageI
 // Marking a change ready for review also adds all of the reviewers of the change to the attention set.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-ready-for-review
-func (s *ChangesService) SetReadyForReview(changeID string, input *ReadyForReviewInput) (*Response, error) {
+func (s *ChangesService) SetReadyForReview(ctx context.Context, changeID string, input *ReadyForReviewInput) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/ready", changeID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, err
 	}
@@ -822,10 +823,10 @@ func (s *ChangesService) SetReadyForReview(changeID string, input *ReadyForRevie
 // The new topic must be provided in the request body inside a TopicInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-topic
-func (s *ChangesService) SetTopic(changeID string, input *TopicInput) (*string, *Response, error) {
+func (s *ChangesService) SetTopic(ctx context.Context, changeID string, input *TopicInput) (*string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/topic", changeID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -846,9 +847,9 @@ func (s *ChangesService) SetTopic(changeID string, input *TopicInput) (*string, 
 // In this case, if you want to specify a commit message, use PUT to delete the topic.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-topic
-func (s *ChangesService) DeleteTopic(changeID string) (*Response, error) {
+func (s *ChangesService) DeleteTopic(ctx context.Context, changeID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/topic", changeID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteChange deletes a new or abandoned change
@@ -857,18 +858,18 @@ func (s *ChangesService) DeleteTopic(changeID string) (*Response, error) {
 // permission, otherwise only by administrators.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-change
-func (s *ChangesService) DeleteChange(changeID string) (*Response, error) {
+func (s *ChangesService) DeleteChange(ctx context.Context, changeID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s", changeID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // PublishDraftChange publishes a draft change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#publish-draft-change
-func (s *ChangesService) PublishDraftChange(changeID, notify string) (*Response, error) {
+func (s *ChangesService) PublishDraftChange(ctx context.Context, changeID, notify string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/publish", changeID)
 
-	req, err := s.client.NewRequest("POST", u, map[string]string{
+	req, err := s.client.NewRequest(ctx, "POST", u, map[string]string{
 		"notify": notify,
 	})
 	if err != nil {
@@ -880,10 +881,10 @@ func (s *ChangesService) PublishDraftChange(changeID, notify string) (*Response,
 // IndexChange adds or updates the change in the secondary index.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#index-change
-func (s *ChangesService) IndexChange(changeID string) (*Response, error) {
+func (s *ChangesService) IndexChange(ctx context.Context, changeID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/index", changeID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -897,10 +898,10 @@ func (s *ChangesService) IndexChange(changeID string) (*Response, error) {
 // Only the change owner, a project owner, or an administrator may fix changes.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#fix-change
-func (s *ChangesService) FixChange(changeID string, input *FixInput) (*ChangeInfo, *Response, error) {
+func (s *ChangesService) FixChange(ctx context.Context, changeID string, input *FixInput) (*ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/check", changeID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -916,9 +917,9 @@ func (s *ChangesService) FixChange(changeID string, input *FixInput) (*ChangeInf
 
 // change is an internal function to consolidate code used by SubmitChange,
 // AbandonChange and other similar functions.
-func (s *ChangesService) change(tail string, changeID string, input interface{}) (*ChangeInfo, *Response, error) {
+func (s *ChangesService) change(ctx context.Context, tail string, changeID string, input interface{}) (*ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/%s", changeID, tail)
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -943,8 +944,8 @@ func (s *ChangesService) change(tail string, changeID string, input interface{})
 // The request body only needs to include a SubmitInput entity if submitting on behalf of another user.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#submit-change
-func (s *ChangesService) SubmitChange(changeID string, input *SubmitInput) (*ChangeInfo, *Response, error) {
-	return s.change("submit", changeID, input)
+func (s *ChangesService) SubmitChange(ctx context.Context, changeID string, input *SubmitInput) (*ChangeInfo, *Response, error) {
+	return s.change(ctx, "submit", changeID, input)
 }
 
 // AbandonChange abandons a change.
@@ -953,8 +954,8 @@ func (s *ChangesService) SubmitChange(changeID string, input *SubmitInput) (*Cha
 // comment is added.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#abandon-change
-func (s *ChangesService) AbandonChange(changeID string, input *AbandonInput) (*ChangeInfo, *Response, error) {
-	return s.change("abandon", changeID, input)
+func (s *ChangesService) AbandonChange(ctx context.Context, changeID string, input *AbandonInput) (*ChangeInfo, *Response, error) {
+	return s.change(ctx, "abandon", changeID, input)
 }
 
 // RebaseChange rebases a change.
@@ -963,8 +964,8 @@ func (s *ChangesService) AbandonChange(changeID string, input *AbandonInput) (*C
 // the RebaseInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#rebase-change
-func (s *ChangesService) RebaseChange(changeID string, input *RebaseInput) (*ChangeInfo, *Response, error) {
-	return s.change("rebase", changeID, input)
+func (s *ChangesService) RebaseChange(ctx context.Context, changeID string, input *RebaseInput) (*ChangeInfo, *Response, error) {
+	return s.change(ctx, "rebase", changeID, input)
 }
 
 // RestoreChange restores a change.
@@ -973,8 +974,8 @@ func (s *ChangesService) RebaseChange(changeID string, input *RebaseInput) (*Cha
 // comment is added.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#restore-change
-func (s *ChangesService) RestoreChange(changeID string, input *RestoreInput) (*ChangeInfo, *Response, error) {
-	return s.change("restore", changeID, input)
+func (s *ChangesService) RestoreChange(ctx context.Context, changeID string, input *RestoreInput) (*ChangeInfo, *Response, error) {
+	return s.change(ctx, "restore", changeID, input)
 }
 
 // RevertChange reverts a change.
@@ -983,8 +984,8 @@ func (s *ChangesService) RestoreChange(changeID string, input *RestoreInput) (*C
 // review comment is added.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#revert-change
-func (s *ChangesService) RevertChange(changeID string, input *RevertInput) (*ChangeInfo, *Response, error) {
-	return s.change("revert", changeID, input)
+func (s *ChangesService) RevertChange(ctx context.Context, changeID string, input *RevertInput) (*ChangeInfo, *Response, error) {
+	return s.change(ctx, "revert", changeID, input)
 }
 
 // MoveChange moves a change.
@@ -994,6 +995,6 @@ func (s *ChangesService) RevertChange(changeID string, input *RevertInput) (*Cha
 // branch by default.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#move-change
-func (s *ChangesService) MoveChange(changeID string, input *MoveInput) (*ChangeInfo, *Response, error) {
-	return s.change("move", changeID, input)
+func (s *ChangesService) MoveChange(ctx context.Context, changeID string, input *MoveInput) (*ChangeInfo, *Response, error) {
+	return s.change(ctx, "move", changeID, input)
 }

--- a/changes_attention.go
+++ b/changes_attention.go
@@ -1,6 +1,9 @@
 package gerrit
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // AttentionSetInfo entity contains details of users that are in the attention set.
 //
@@ -32,8 +35,8 @@ type AttentionSetInput struct {
 // AttentionSetInput.Input must be provided
 //
 // https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#remove-from-attention-set
-func (s *ChangesService) RemoveAttention(changeID, accountID string, input *AttentionSetInput) (*Response, error) {
+func (s *ChangesService) RemoveAttention(ctx context.Context, changeID, accountID string, input *AttentionSetInput) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/attention/%s", changeID, accountID)
 
-	return s.client.DeleteRequest(u, input)
+	return s.client.DeleteRequest(ctx, u, input)
 }

--- a/changes_edit.go
+++ b/changes_edit.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -36,7 +37,7 @@ type ChangeEditDetailOptions struct {
 // Edits aren’t tracked in the database.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-edit-detail
-func (s *ChangesService) GetChangeEditDetails(changeID string, opt *ChangeEditDetailOptions) (*EditInfo, *Response, error) {
+func (s *ChangesService) GetChangeEditDetails(ctx context.Context, changeID string, opt *ChangeEditDetailOptions) (*EditInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/edit", changeID)
 
 	u, err := addOptions(u, opt)
@@ -44,7 +45,7 @@ func (s *ChangesService) GetChangeEditDetails(changeID string, opt *ChangeEditDe
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,10 +63,10 @@ func (s *ChangesService) GetChangeEditDetails(changeID string, opt *ChangeEditDe
 // Currently only web links are returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-edit-meta-data
-func (s *ChangesService) RetrieveMetaDataOfAFileFromChangeEdit(changeID, filePath string) (*EditFileInfo, *Response, error) {
+func (s *ChangesService) RetrieveMetaDataOfAFileFromChangeEdit(ctx context.Context, changeID, filePath string) (*EditFileInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/edit/%s/meta", changeID, filePath)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -83,9 +84,9 @@ func (s *ChangesService) RetrieveMetaDataOfAFileFromChangeEdit(changeID, filePat
 // The commit message is returned as base64 encoded string.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-edit-message
-func (s *ChangesService) RetrieveCommitMessageFromChangeEdit(changeID string) (string, *Response, error) {
+func (s *ChangesService) RetrieveCommitMessageFromChangeEdit(ctx context.Context, changeID string) (string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/edit:message", changeID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // ChangeFileContentInChangeEdit put content of a file to a change edit.
@@ -95,10 +96,10 @@ func (s *ChangesService) RetrieveCommitMessageFromChangeEdit(changeID string) (s
 // As response “204 No Content” is returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#put-edit-file
-func (s *ChangesService) ChangeFileContentInChangeEdit(changeID, filePath, content string) (*Response, error) {
+func (s *ChangesService) ChangeFileContentInChangeEdit(ctx context.Context, changeID, filePath, content string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/edit/%s", changeID, url.QueryEscape(filePath))
 
-	req, err := s.client.NewRawPutRequest(u, content)
+	req, err := s.client.NewRawPutRequest(ctx, u, content)
 	if err != nil {
 		return nil, err
 	}
@@ -113,10 +114,10 @@ func (s *ChangesService) ChangeFileContentInChangeEdit(changeID, filePath, conte
 // As response “204 No Content” is returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#put-change-edit-message
-func (s *ChangesService) ChangeCommitMessageInChangeEdit(changeID string, input *ChangeEditMessageInput) (*Response, error) {
+func (s *ChangesService) ChangeCommitMessageInChangeEdit(ctx context.Context, changeID string, input *ChangeEditMessageInput) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/edit:message", changeID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, err
 	}
@@ -131,9 +132,9 @@ func (s *ChangesService) ChangeCommitMessageInChangeEdit(changeID string, input 
 // When change edit doesn’t exist for this change yet it is created.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-edit-file
-func (s *ChangesService) DeleteFileInChangeEdit(changeID, filePath string) (*Response, error) {
+func (s *ChangesService) DeleteFileInChangeEdit(ctx context.Context, changeID, filePath string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/edit/%s", changeID, filePath)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteChangeEdit deletes change edit.
@@ -141,9 +142,9 @@ func (s *ChangesService) DeleteFileInChangeEdit(changeID, filePath string) (*Res
 // As response “204 No Content” is returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-edit
-func (s *ChangesService) DeleteChangeEdit(changeID string) (*Response, error) {
+func (s *ChangesService) DeleteChangeEdit(ctx context.Context, changeID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/edit", changeID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // PublishChangeEdit promotes change edit to a regular patch set.
@@ -151,10 +152,10 @@ func (s *ChangesService) DeleteChangeEdit(changeID string) (*Response, error) {
 // As response “204 No Content” is returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#publish-edit
-func (s *ChangesService) PublishChangeEdit(changeID, notify string) (*Response, error) {
+func (s *ChangesService) PublishChangeEdit(ctx context.Context, changeID, notify string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/edit:publish", changeID)
 
-	req, err := s.client.NewRequest("POST", u, map[string]string{
+	req, err := s.client.NewRequest(ctx, "POST", u, map[string]string{
 		"notify": notify,
 	})
 	if err != nil {
@@ -169,10 +170,10 @@ func (s *ChangesService) PublishChangeEdit(changeID, notify string) (*Response, 
 // When change edit is already based on top of the latest patch set, the response “409 Conflict” is returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#rebase-edit
-func (s *ChangesService) RebaseChangeEdit(changeID string) (*Response, error) {
+func (s *ChangesService) RebaseChangeEdit(ctx context.Context, changeID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/edit:rebase", changeID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -190,10 +191,10 @@ func (s *ChangesService) RebaseChangeEdit(changeID string) (*Response, error) {
 // If only the content type is required, callers should use HEAD to avoid downloading the encoded file contents.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-edit-file
-func (s *ChangesService) RetrieveFileContentFromChangeEdit(changeID, filePath string) (*string, *Response, error) {
+func (s *ChangesService) RetrieveFileContentFromChangeEdit(ctx context.Context, changeID, filePath string) (*string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/edit/%s", changeID, filePath)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -214,10 +215,10 @@ func (s *ChangesService) RetrieveFileContentFromChangeEdit(changeID, filePath st
 // For further documentation please have a look at RetrieveFileContentFromChangeEdit.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-edit-file
-func (s *ChangesService) RetrieveFileContentTypeFromChangeEdit(changeID, filePath string) (*Response, error) {
+func (s *ChangesService) RetrieveFileContentTypeFromChangeEdit(ctx context.Context, changeID, filePath string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/edit/%s", changeID, filePath)
 
-	req, err := s.client.NewRequest("HEAD", u, nil)
+	req, err := s.client.NewRequest(ctx, "HEAD", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/changes_hashtags.go
+++ b/changes_hashtags.go
@@ -1,14 +1,17 @@
 package gerrit
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // GetHashtags gets the hashtags associated with a change.
 //
 // https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-hashtags
-func (c *ChangesService) GetHashtags(changeID string) ([]string, *Response, error) {
+func (c *ChangesService) GetHashtags(ctx context.Context, changeID string) ([]string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/hashtags", changeID)
 
-	req, err := c.client.NewRequest("GET", u, nil)
+	req, err := c.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -35,10 +38,10 @@ type HashtagsInput struct {
 // As response the change’s hashtags are returned as a list of strings.
 //
 // https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-hashtags
-func (c *ChangesService) SetHashtags(changeID string, input *HashtagsInput) ([]string, *Response, error) {
+func (c *ChangesService) SetHashtags(ctx context.Context, changeID string, input *HashtagsInput) ([]string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/hashtags", changeID)
 
-	req, err := c.client.NewRequest("POST", u, input)
+	req, err := c.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/changes_hashtags_test.go
+++ b/changes_hashtags_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -30,12 +31,13 @@ func TestChangesService_GetHashtags(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	hashtags, _, err := client.Changes.GetHashtags("123")
+	hashtags, _, err := client.Changes.GetHashtags(ctx, "123")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,12 +68,13 @@ func TestChangesService_SetHashtags(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	hashtags, _, err := client.Changes.SetHashtags("123", &gerrit.HashtagsInput{
+	hashtags, _, err := client.Changes.SetHashtags(ctx, "123", &gerrit.HashtagsInput{
 		Add:    []string{"hashtag3"},
 		Remove: []string{"hashtag2"},
 	})

--- a/changes_reviewer.go
+++ b/changes_reviewer.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -37,10 +38,10 @@ type DeleteVoteInput struct {
 // ListReviewers lists the reviewers of a change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-reviewers
-func (s *ChangesService) ListReviewers(changeID string) (*[]ReviewerInfo, *Response, error) {
+func (s *ChangesService) ListReviewers(ctx context.Context, changeID string) (*[]ReviewerInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/reviewers/", changeID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -58,7 +59,7 @@ func (s *ChangesService) ListReviewers(changeID string) (*[]ReviewerInfo, *Respo
 // If result limit is not passed, then the default 10 is used.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#suggest-reviewers
-func (s *ChangesService) SuggestReviewers(changeID string, opt *QueryOptions) (*[]SuggestedReviewerInfo, *Response, error) {
+func (s *ChangesService) SuggestReviewers(ctx context.Context, changeID string, opt *QueryOptions) (*[]SuggestedReviewerInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/suggest_reviewers", changeID)
 
 	u, err := addOptions(u, opt)
@@ -66,7 +67,7 @@ func (s *ChangesService) SuggestReviewers(changeID string, opt *QueryOptions) (*
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -83,10 +84,10 @@ func (s *ChangesService) SuggestReviewers(changeID string, opt *QueryOptions) (*
 // GetReviewer retrieves a reviewer of a change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-reviewer
-func (s *ChangesService) GetReviewer(changeID, accountID string) (*ReviewerInfo, *Response, error) {
+func (s *ChangesService) GetReviewer(ctx context.Context, changeID, accountID string) (*ReviewerInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/reviewers/%s", changeID, accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -109,10 +110,10 @@ func (s *ChangesService) GetReviewer(changeID, accountID string) (*ReviewerInfo,
 // If a group with many members is added as reviewer a confirmation may be required.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#add-reviewer
-func (s *ChangesService) AddReviewer(changeID string, input *ReviewerInput) (*AddReviewerResult, *Response, error) {
+func (s *ChangesService) AddReviewer(ctx context.Context, changeID string, input *ReviewerInput) (*AddReviewerResult, *Response, error) {
 	u := fmt.Sprintf("changes/%s/reviewers", changeID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -129,17 +130,17 @@ func (s *ChangesService) AddReviewer(changeID string, input *ReviewerInput) (*Ad
 // DeleteReviewer deletes a reviewer from a change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-reviewer
-func (s *ChangesService) DeleteReviewer(changeID, accountID string) (*Response, error) {
+func (s *ChangesService) DeleteReviewer(ctx context.Context, changeID, accountID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/reviewers/%s", changeID, accountID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // ListVotes lists the votes for a specific reviewer of the change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-votes
-func (s *ChangesService) ListVotes(changeID string, accountID string) (map[string]int, *Response, error) {
+func (s *ChangesService) ListVotes(ctx context.Context, changeID string, accountID string) (map[string]int, *Response, error) {
 	u := fmt.Sprintf("changes/%s/reviewers/%s/votes/", changeID, accountID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -157,7 +158,7 @@ func (s *ChangesService) ListVotes(changeID string, accountID string) (map[strin
 // the change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-vote
-func (s *ChangesService) DeleteVote(changeID string, accountID string, label string, input *DeleteVoteInput) (*Response, error) {
+func (s *ChangesService) DeleteVote(ctx context.Context, changeID string, accountID string, label string, input *DeleteVoteInput) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/reviewers/%s/votes/%s", changeID, accountID, label)
-	return s.client.DeleteRequest(u, input)
+	return s.client.DeleteRequest(ctx, u, input)
 }

--- a/changes_reviewer_test.go
+++ b/changes_reviewer_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -9,8 +10,8 @@ import (
 	"github.com/andygrunwald/go-gerrit"
 )
 
-func newClient(t *testing.T, server *httptest.Server) *gerrit.Client {
-	client, err := gerrit.NewClient(server.URL, nil)
+func newClient(ctx context.Context, t *testing.T, server *httptest.Server) *gerrit.Client {
+	client, err := gerrit.NewClient(ctx, server.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -28,8 +29,9 @@ func TestChangesService_ListReviewers(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := newClient(t, ts)
-	data, _, err := client.Changes.ListReviewers("123")
+	ctx := context.Background()
+	client := newClient(ctx, t, ts)
+	data, _, err := client.Changes.ListReviewers(ctx, "123")
 	if err != nil {
 		t.Error(err)
 	}
@@ -54,8 +56,9 @@ func TestChangesService_SuggestReviewers(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := newClient(t, ts)
-	data, _, err := client.Changes.SuggestReviewers("123", nil)
+	ctx := context.Background()
+	client := newClient(ctx, t, ts)
+	data, _, err := client.Changes.SuggestReviewers(ctx, "123", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -80,8 +83,9 @@ func TestChangesService_GetReviewer(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := newClient(t, ts)
-	data, _, err := client.Changes.GetReviewer("123", "1")
+	ctx := context.Background()
+	client := newClient(ctx, t, ts)
+	data, _, err := client.Changes.GetReviewer(ctx, "123", "1")
 	if err != nil {
 		t.Error(err)
 	}
@@ -104,8 +108,9 @@ func TestChangesService_AddReviewer(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := newClient(t, ts)
-	data, _, err := client.Changes.AddReviewer("123", &gerrit.ReviewerInput{})
+	ctx := context.Background()
+	client := newClient(ctx, t, ts)
+	data, _, err := client.Changes.AddReviewer(ctx, "123", &gerrit.ReviewerInput{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -127,8 +132,9 @@ func TestChangesService_DeleteReviewer(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := newClient(t, ts)
-	_, err := client.Changes.DeleteReviewer("123", "1")
+	ctx := context.Background()
+	client := newClient(ctx, t, ts)
+	_, err := client.Changes.DeleteReviewer(ctx, "123", "1")
 	if err != nil {
 		t.Error(err)
 	}
@@ -144,8 +150,9 @@ func TestChangesService_ListVotes(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := newClient(t, ts)
-	votes, _, err := client.Changes.ListVotes("123", "1")
+	ctx := context.Background()
+	client := newClient(ctx, t, ts)
+	votes, _, err := client.Changes.ListVotes(ctx, "123", "1")
 	if err != nil {
 		t.Error(err)
 	}
@@ -171,8 +178,9 @@ func TestChangesService_DeleteVote(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := newClient(t, ts)
-	_, err := client.Changes.DeleteVote("123", "1", "Code-Review", nil)
+	ctx := context.Background()
+	client := newClient(ctx, t, ts)
+	_, err := client.Changes.DeleteVote(ctx, "123", "1", "Code-Review", nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/changes_revision.go
+++ b/changes_revision.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -142,7 +143,7 @@ type PatchOptions struct {
 // GetDiff gets the diff of a file from a certain revision.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-diff
-func (s *ChangesService) GetDiff(changeID, revisionID, fileID string, opt *DiffOptions) (*DiffInfo, *Response, error) {
+func (s *ChangesService) GetDiff(ctx context.Context, changeID, revisionID, fileID string, opt *DiffOptions) (*DiffInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/diff", changeID, revisionID, url.PathEscape(fileID))
 
 	u, err := addOptions(u, opt)
@@ -150,7 +151,7 @@ func (s *ChangesService) GetDiff(changeID, revisionID, fileID string, opt *DiffO
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -168,10 +169,10 @@ func (s *ChangesService) GetDiff(changeID, revisionID, fileID string, opt *DiffO
 // Related changes are changes that either depend on, or are dependencies of the revision.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-related-changes
-func (s *ChangesService) GetRelatedChanges(changeID, revisionID string) (*RelatedChangesInfo, *Response, error) {
+func (s *ChangesService) GetRelatedChanges(ctx context.Context, changeID, revisionID string) (*RelatedChangesInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/related", changeID, revisionID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -188,34 +189,34 @@ func (s *ChangesService) GetRelatedChanges(changeID, revisionID string) (*Relate
 // GetDraft retrieves a draft comment of a revision that belongs to the calling user.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-draft
-func (s *ChangesService) GetDraft(changeID, revisionID, draftID string) (*CommentInfo, *Response, error) {
+func (s *ChangesService) GetDraft(ctx context.Context, changeID, revisionID, draftID string) (*CommentInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/drafts/%s", changeID, revisionID, draftID)
-	return s.getCommentInfoResponse(u)
+	return s.getCommentInfoResponse(ctx, u)
 }
 
 // GetComment retrieves a published comment of a revision.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-comment
-func (s *ChangesService) GetComment(changeID, revisionID, commentID string) (*CommentInfo, *Response, error) {
+func (s *ChangesService) GetComment(ctx context.Context, changeID, revisionID, commentID string) (*CommentInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/comments/%s", changeID, revisionID, commentID)
-	return s.getCommentInfoResponse(u)
+	return s.getCommentInfoResponse(ctx, u)
 }
 
 // GetSubmitType gets the method the server will use to submit (merge) the change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-submit-type
-func (s *ChangesService) GetSubmitType(changeID, revisionID string) (string, *Response, error) {
+func (s *ChangesService) GetSubmitType(ctx context.Context, changeID, revisionID string) (string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/submit_type", changeID, revisionID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // GetRevisionActions retrieves revision actions of the revision of a change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-revision-actions
-func (s *ChangesService) GetRevisionActions(changeID, revisionID string) (*map[string]ActionInfo, *Response, error) {
+func (s *ChangesService) GetRevisionActions(ctx context.Context, changeID, revisionID string) (*map[string]ActionInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/actions", changeID, revisionID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -232,7 +233,7 @@ func (s *ChangesService) GetRevisionActions(changeID, revisionID string) (*map[s
 // GetCommit retrieves a parsed commit of a revision.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-commit
-func (s *ChangesService) GetCommit(changeID, revisionID string, opt *CommitOptions) (*CommitInfo, *Response, error) {
+func (s *ChangesService) GetCommit(ctx context.Context, changeID, revisionID string, opt *CommitOptions) (*CommitInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/commit", changeID, revisionID)
 
 	u, err := addOptions(u, opt)
@@ -240,7 +241,7 @@ func (s *ChangesService) GetCommit(changeID, revisionID string, opt *CommitOptio
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -262,15 +263,15 @@ func (s *ChangesService) GetCommit(changeID, revisionID string, opt *CommitOptio
 // Please note that the returned labels are always for the current patch set.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-review
-func (s *ChangesService) GetReview(changeID, revisionID string) (*ChangeInfo, *Response, error) {
+func (s *ChangesService) GetReview(ctx context.Context, changeID, revisionID string) (*ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/review", changeID, revisionID)
-	return s.getChangeInfoResponse(u, nil)
+	return s.getChangeInfoResponse(ctx, u, nil)
 }
 
 // GetMergeable gets the method the server will use to submit (merge) the change and an indicator if the change is currently mergeable.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-mergeable
-func (s *ChangesService) GetMergeable(changeID, revisionID string, opt *MergableOptions) (*MergeableInfo, *Response, error) {
+func (s *ChangesService) GetMergeable(ctx context.Context, changeID, revisionID string, opt *MergableOptions) (*MergeableInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/mergeable", changeID, revisionID)
 
 	u, err := addOptions(u, opt)
@@ -278,7 +279,7 @@ func (s *ChangesService) GetMergeable(changeID, revisionID string, opt *Mergable
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -297,9 +298,9 @@ func (s *ChangesService) GetMergeable(changeID, revisionID string, opt *Mergable
 // The entries in the map are sorted by file path.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-drafts
-func (s *ChangesService) ListRevisionDrafts(changeID, revisionID string) (*map[string][]CommentInfo, *Response, error) {
+func (s *ChangesService) ListRevisionDrafts(ctx context.Context, changeID, revisionID string) (*map[string][]CommentInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/drafts/", changeID, revisionID)
-	return s.getCommentInfoMapSliceResponse(u)
+	return s.getCommentInfoMapSliceResponse(ctx, u)
 }
 
 // ListRevisionComments lists the published comments of a revision.
@@ -308,9 +309,9 @@ func (s *ChangesService) ListRevisionDrafts(changeID, revisionID string) (*map[s
 // Use the Get Change Detail endpoint to retrieve the general change message (or comment).
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-comments
-func (s *ChangesService) ListRevisionComments(changeID, revisionID string) (*map[string][]CommentInfo, *Response, error) {
+func (s *ChangesService) ListRevisionComments(ctx context.Context, changeID, revisionID string) (*map[string][]CommentInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/comments/", changeID, revisionID)
-	return s.getCommentInfoMapSliceResponse(u)
+	return s.getCommentInfoMapSliceResponse(ctx, u)
 }
 
 // ListFiles lists the files that were modified, added or deleted in a revision.
@@ -318,7 +319,7 @@ func (s *ChangesService) ListRevisionComments(changeID, revisionID string) (*map
 // The entries in the map are sorted by file path.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-files
-func (s *ChangesService) ListFiles(changeID, revisionID string, opt *FilesOptions) (map[string]FileInfo, *Response, error) {
+func (s *ChangesService) ListFiles(ctx context.Context, changeID, revisionID string, opt *FilesOptions) (map[string]FileInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/files/", changeID, revisionID)
 
 	u, err := addOptions(u, opt)
@@ -326,7 +327,7 @@ func (s *ChangesService) ListFiles(changeID, revisionID string, opt *FilesOption
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -345,7 +346,7 @@ func (s *ChangesService) ListFiles(changeID, revisionID string, opt *FilesOption
 // has marked as reviewed. Clients that also need the FileInfo should make two requests.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-files
-func (s *ChangesService) ListFilesReviewed(changeID, revisionID string, opt *FilesOptions) ([]string, *Response, error) {
+func (s *ChangesService) ListFilesReviewed(ctx context.Context, changeID, revisionID string, opt *FilesOptions) ([]string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/files/", changeID, revisionID)
 
 	o := struct {
@@ -364,7 +365,7 @@ func (s *ChangesService) ListFilesReviewed(changeID, revisionID string, opt *Fil
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -382,10 +383,10 @@ func (s *ChangesService) ListFilesReviewed(changeID, revisionID string, opt *Fil
 // The review must be provided in the request body as a ReviewInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-review
-func (s *ChangesService) SetReview(changeID, revisionID string, input *ReviewInput) (*ReviewResult, *Response, error) {
+func (s *ChangesService) SetReview(ctx context.Context, changeID, revisionID string, input *ReviewInput) (*ReviewResult, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/review", changeID, revisionID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -402,10 +403,10 @@ func (s *ChangesService) SetReview(changeID, revisionID string, input *ReviewInp
 // PublishDraftRevision publishes a draft revision.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#publish-draft-revision
-func (s *ChangesService) PublishDraftRevision(changeID, revisionID string) (*Response, error) {
+func (s *ChangesService) PublishDraftRevision(ctx context.Context, changeID, revisionID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/publish", changeID, revisionID)
 
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -416,9 +417,9 @@ func (s *ChangesService) PublishDraftRevision(changeID, revisionID string) (*Res
 // DeleteDraftRevision deletes a draft revision.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-draft-revision
-func (s *ChangesService) DeleteDraftRevision(changeID, revisionID string) (*Response, error) {
+func (s *ChangesService) DeleteDraftRevision(ctx context.Context, changeID, revisionID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s", changeID, revisionID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // GetPatch gets the formatted patch for one revision.
@@ -431,7 +432,7 @@ func (s *ChangesService) DeleteDraftRevision(changeID, revisionID string) (*Resp
 // Query parameter download (e.g. /changes/.../patch?download) will suggest the browser save the patch as commitsha1.diff.base64, for later processing by command line tools.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-patch
-func (s *ChangesService) GetPatch(changeID, revisionID string, opt *PatchOptions) (*string, *Response, error) {
+func (s *ChangesService) GetPatch(ctx context.Context, changeID, revisionID string, opt *PatchOptions) (*string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/patch", changeID, revisionID)
 
 	u, err := addOptions(u, opt)
@@ -439,7 +440,7 @@ func (s *ChangesService) GetPatch(changeID, revisionID string, opt *PatchOptions
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -459,10 +460,10 @@ func (s *ChangesService) GetPatch(changeID, revisionID string, opt *PatchOptions
 // The query parameter filters may be set to SKIP to bypass parent project filters while testing a project-specific rule.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#test-submit-type
-func (s *ChangesService) TestSubmitType(changeID, revisionID string, input *RuleInput) (*string, *Response, error) {
+func (s *ChangesService) TestSubmitType(ctx context.Context, changeID, revisionID string, input *RuleInput) (*string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/test.submit_type", changeID, revisionID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -484,10 +485,10 @@ func (s *ChangesService) TestSubmitType(changeID, revisionID string, input *Rule
 // The response is a list of SubmitRecord entries describing the permutations that satisfy the tested submit rule.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#test-submit-rule
-func (s *ChangesService) TestSubmitRule(changeID, revisionID string, input *RuleInput) (*[]SubmitRecord, *Response, error) {
+func (s *ChangesService) TestSubmitRule(ctx context.Context, changeID, revisionID string, input *RuleInput) (*[]SubmitRecord, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/test.submit_rule", changeID, revisionID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -507,10 +508,10 @@ func (s *ChangesService) TestSubmitRule(changeID, revisionID string, input *Rule
 // As response a CommentInfo entity is returned that describes the draft comment.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#create-draft
-func (s *ChangesService) CreateDraft(changeID, revisionID string, input *CommentInput) (*CommentInfo, *Response, error) {
+func (s *ChangesService) CreateDraft(ctx context.Context, changeID, revisionID string, input *CommentInput) (*CommentInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/drafts", changeID, revisionID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -530,10 +531,10 @@ func (s *ChangesService) CreateDraft(changeID, revisionID string, input *Comment
 // As response a CommentInfo entity is returned that describes the draft comment.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#update-draft
-func (s *ChangesService) UpdateDraft(changeID, revisionID, draftID string, input *CommentInput) (*CommentInfo, *Response, error) {
+func (s *ChangesService) UpdateDraft(ctx context.Context, changeID, revisionID, draftID string, input *CommentInput) (*CommentInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/drafts/%s", changeID, revisionID, draftID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -550,17 +551,17 @@ func (s *ChangesService) UpdateDraft(changeID, revisionID, draftID string, input
 // DeleteDraft deletes a draft comment from a revision.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-draft
-func (s *ChangesService) DeleteDraft(changeID, revisionID, draftID string) (*Response, error) {
+func (s *ChangesService) DeleteDraft(ctx context.Context, changeID, revisionID, draftID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/drafts/%s", changeID, revisionID, draftID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteReviewed deletes the reviewed flag of the calling user from a file of a revision.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-reviewed
-func (s *ChangesService) DeleteReviewed(changeID, revisionID, fileID string) (*Response, error) {
+func (s *ChangesService) DeleteReviewed(ctx context.Context, changeID, revisionID, fileID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/reviewed", changeID, revisionID, url.PathEscape(fileID))
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // GetContent gets the content of a file from a certain revision.
@@ -569,10 +570,10 @@ func (s *ChangesService) DeleteReviewed(changeID, revisionID, fileID string) (*R
 // A Gerrit-specific X-FYI-Content-Type header is returned describing the server detected content type of the file.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-content
-func (s *ChangesService) GetContent(changeID, revisionID, fileID string) (*string, *Response, error) {
+func (s *ChangesService) GetContent(ctx context.Context, changeID, revisionID, fileID string) (*string, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/content", changeID, revisionID, url.PathEscape(fileID))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -593,10 +594,10 @@ func (s *ChangesService) GetContent(changeID, revisionID, fileID string) (*strin
 // For further documentation see GetContent.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-content
-func (s *ChangesService) GetContentType(changeID, revisionID, fileID string) (*Response, error) {
+func (s *ChangesService) GetContentType(ctx context.Context, changeID, revisionID, fileID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/content", changeID, revisionID, url.PathEscape(fileID))
 
-	req, err := s.client.NewRequest("HEAD", u, nil)
+	req, err := s.client.NewRequest(ctx, "HEAD", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -609,10 +610,10 @@ func (s *ChangesService) GetContentType(changeID, revisionID, fileID string) (*R
 // If the file was already marked as reviewed by the calling user the response is “200 OK”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-reviewed
-func (s *ChangesService) SetReviewed(changeID, revisionID, fileID string) (*Response, error) {
+func (s *ChangesService) SetReviewed(ctx context.Context, changeID, revisionID, fileID string) (*Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/files/%s/reviewed", changeID, revisionID, url.PathEscape(fileID))
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -626,10 +627,10 @@ func (s *ChangesService) SetReviewed(changeID, revisionID, fileID string) (*Resp
 // As response a ChangeInfo entity is returned that describes the resulting cherry picked change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#cherry-pick
-func (s *ChangesService) CherryPickRevision(changeID, revisionID string, input *CherryPickInput) (*ChangeInfo, *Response, error) {
+func (s *ChangesService) CherryPickRevision(ctx context.Context, changeID, revisionID string, input *CherryPickInput) (*ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("changes/%s/revisions/%s/cherrypick", changeID, revisionID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/changes_revision_test.go
+++ b/changes_revision_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -32,8 +33,9 @@ func TestChangesService_ListFiles(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := newClient(t, ts)
-	got, _, err := client.Changes.ListFiles("123", "456", &gerrit.FilesOptions{
+	ctx := context.Background()
+	client := newClient(ctx, t, ts)
+	got, _, err := client.Changes.ListFiles(ctx, "123", "456", &gerrit.FilesOptions{
 		Base: "7",
 	})
 	if err != nil {
@@ -67,8 +69,9 @@ func TestChangesService_ListFilesReviewed(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := newClient(t, ts)
-	got, _, err := client.Changes.ListFilesReviewed("123", "456", &gerrit.FilesOptions{
+	ctx := context.Background()
+	client := newClient(ctx, t, ts)
+	got, _, err := client.Changes.ListFilesReviewed(ctx, "123", "456", &gerrit.FilesOptions{
 		Q: "abc",
 	})
 	if err != nil {

--- a/changes_test.go
+++ b/changes_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,8 +12,9 @@ import (
 )
 
 func ExampleChangesService_QueryChanges() {
+	ctx := context.Background()
 	instance := "https://android-review.googlesource.com/"
-	client, err := gerrit.NewClient(instance, nil)
+	client, err := gerrit.NewClient(ctx, instance, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -23,7 +25,7 @@ func ExampleChangesService_QueryChanges() {
 	}
 	opt.Limit = 2
 	opt.AdditionalFields = []string{"LABELS"}
-	changes, _, err := client.Changes.QueryChanges(opt)
+	changes, _, err := client.Changes.QueryChanges(ctx, opt)
 	if err != nil {
 		panic(err)
 	}
@@ -38,7 +40,8 @@ func ExampleChangesService_QueryChanges() {
 
 func ExampleChangesService_QueryChanges_withSubmittable() {
 	instance := "https://android-review.googlesource.com/"
-	client, err := gerrit.NewClient(instance, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, instance, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +52,7 @@ func ExampleChangesService_QueryChanges_withSubmittable() {
 	}
 	opt.AdditionalFields = []string{"SUBMITTABLE"}
 
-	changes, _, err := client.Changes.QueryChanges(opt)
+	changes, _, err := client.Changes.QueryChanges(ctx, opt)
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +68,8 @@ func ExampleChangesService_QueryChanges_withSubmittable() {
 // Prior to fixing #18 this test would fail.
 func ExampleChangesService_QueryChanges_withSymbols() {
 	instance := "https://android-review.googlesource.com/"
-	client, err := gerrit.NewClient(instance, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, instance, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -76,7 +80,7 @@ func ExampleChangesService_QueryChanges_withSymbols() {
 	}
 	opt.Limit = 2
 	opt.AdditionalFields = []string{"LABELS"}
-	changes, _, err := client.Changes.QueryChanges(opt)
+	changes, _, err := client.Changes.QueryChanges(ctx, opt)
 	if err != nil {
 		panic(err)
 	}
@@ -95,12 +99,13 @@ func ExampleChangesService_PublishChangeEdit() {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		panic(err)
 	}
 
-	_, err = client.Changes.PublishChangeEdit("123", "NONE")
+	_, err = client.Changes.PublishChangeEdit(ctx, "123", "NONE")
 	if err != nil {
 		panic(err)
 	}
@@ -169,7 +174,8 @@ func TestChangesService_CreateChange(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -200,7 +206,7 @@ func TestChangesService_CreateChange(t *testing.T) {
 	}
 	for name, input := range cases {
 		t.Run(name, func(t *testing.T) {
-			info, _, err := client.Changes.CreateChange(&input)
+			info, _, err := client.Changes.CreateChange(ctx, &input)
 			if err != nil {
 				t.Error(err)
 			}
@@ -221,11 +227,12 @@ func TestChangesService_SubmitChange(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	info, _, err := client.Changes.SubmitChange("123", nil)
+	info, _, err := client.Changes.SubmitChange(ctx, "123", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -240,11 +247,12 @@ func TestChangesService_SubmitChange_Conflict(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	_, response, _ := client.Changes.SubmitChange("123", nil)
+	_, response, _ := client.Changes.SubmitChange(ctx, "123", nil)
 	if response.StatusCode != http.StatusConflict {
 		t.Error("Expected 409 code")
 	}
@@ -259,11 +267,12 @@ func TestChangesService_AbandonChange(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	info, _, err := client.Changes.AbandonChange("123", nil)
+	info, _, err := client.Changes.AbandonChange(ctx, "123", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -278,11 +287,12 @@ func TestChangesService_AbandonChange_Conflict(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	_, response, _ := client.Changes.AbandonChange("123", nil)
+	_, response, _ := client.Changes.AbandonChange(ctx, "123", nil)
 	if response.StatusCode != http.StatusConflict {
 		t.Error("Expected 409 code")
 	}
@@ -297,11 +307,12 @@ func TestChangesService_RebaseChange(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	info, _, err := client.Changes.RebaseChange("123", nil)
+	info, _, err := client.Changes.RebaseChange(ctx, "123", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -316,11 +327,12 @@ func TestChangesService_RebaseChange_Conflict(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	_, response, _ := client.Changes.RebaseChange("123", nil)
+	_, response, _ := client.Changes.RebaseChange(ctx, "123", nil)
 	if response.StatusCode != http.StatusConflict {
 		t.Error("Expected 409 code")
 	}
@@ -335,11 +347,12 @@ func TestChangesService_RestoreChange(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	info, _, err := client.Changes.RestoreChange("123", nil)
+	info, _, err := client.Changes.RestoreChange(ctx, "123", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -354,11 +367,12 @@ func TestChangesService_RestoreChange_Conflict(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	_, response, _ := client.Changes.RestoreChange("123", nil)
+	_, response, _ := client.Changes.RestoreChange(ctx, "123", nil)
 	if response.StatusCode != http.StatusConflict {
 		t.Error("Expected 409 code")
 	}
@@ -373,11 +387,12 @@ func TestChangesService_RevertChange(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	info, _, err := client.Changes.RevertChange("123", nil)
+	info, _, err := client.Changes.RevertChange(ctx, "123", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -392,11 +407,12 @@ func TestChangesService_RevertChange_Conflict(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	_, response, _ := client.Changes.RevertChange("123", nil)
+	_, response, _ := client.Changes.RevertChange(ctx, "123", nil)
 	if response.StatusCode != http.StatusConflict {
 		t.Error("Expected 409 code")
 	}
@@ -414,12 +430,13 @@ func TestChangesService_SetCommitMessage(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
 	cm := &gerrit.CommitMessageInput{Message: "New commit message"}
-	_, err = client.Changes.SetCommitMessage("123", cm)
+	_, err = client.Changes.SetCommitMessage(ctx, "123", cm)
 	if err != nil {
 		t.Error(err)
 	}
@@ -437,12 +454,13 @@ func TestChangesService_SetCommitMessage_NotFound(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
 	cm := &gerrit.CommitMessageInput{Message: "New commit message"}
-	resp, err := client.Changes.SetCommitMessage("123", cm)
+	resp, err := client.Changes.SetCommitMessage(ctx, "123", cm)
 	if err == nil {
 		t.Error("Expected error, instead nil")
 	}
@@ -463,12 +481,13 @@ func TestChangesService_SetReadyForReview(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
 	cm := &gerrit.ReadyForReviewInput{Message: "Now ready for review"}
-	_, err = client.Changes.SetReadyForReview("123", cm)
+	_, err = client.Changes.SetReadyForReview(ctx, "123", cm)
 	if err != nil {
 		t.Error(err)
 	}
@@ -486,12 +505,13 @@ func TestChangesService_SetReadyForReview_NotFound(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := gerrit.NewClient(ts.URL, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, ts.URL, nil)
 	if err != nil {
 		t.Error(err)
 	}
 	cm := &gerrit.ReadyForReviewInput{Message: "Now ready for review"}
-	resp, err := client.Changes.SetReadyForReview("123", cm)
+	resp, err := client.Changes.SetReadyForReview(ctx, "123", cm)
 	if err == nil {
 		t.Error("Expected error, instead nil")
 	}

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -251,18 +252,18 @@ type SummaryOptions struct {
 // GetVersion returns the version of the Gerrit server.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#get-version
-func (s *ConfigService) GetVersion() (string, *Response, error) {
+func (s *ConfigService) GetVersion(ctx context.Context) (string, *Response, error) {
 	u := "config/server/version"
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // GetServerInfo returns the information about the Gerrit server configuration.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#get-info
-func (s *ConfigService) GetServerInfo() (*ServerInfo, *Response, error) {
+func (s *ConfigService) GetServerInfo(ctx context.Context) (*ServerInfo, *Response, error) {
 	u := "config/server/info"
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -284,7 +285,7 @@ func (s *ConfigService) GetServerInfo() (*ServerInfo, *Response, error) {
 // The entries in the map are sorted by cache name.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#list-caches
-func (s *ConfigService) ListCaches(opt *ListCachesOptions) (*map[string]CacheInfo, *Response, error) {
+func (s *ConfigService) ListCaches(ctx context.Context, opt *ListCachesOptions) (*map[string]CacheInfo, *Response, error) {
 	u := "config/server/caches/"
 
 	u, err := addOptions(u, opt)
@@ -292,7 +293,7 @@ func (s *ConfigService) ListCaches(opt *ListCachesOptions) (*map[string]CacheInf
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -313,10 +314,10 @@ func (s *ConfigService) ListCaches(opt *ListCachesOptions) (*map[string]CacheInf
 // * Administrate Server
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#get-cache
-func (s *ConfigService) GetCache(cacheName string) (*CacheInfo, *Response, error) {
+func (s *ConfigService) GetCache(ctx context.Context, cacheName string) (*CacheInfo, *Response, error) {
 	u := fmt.Sprintf("config/server/caches/%s", cacheName)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -334,7 +335,7 @@ func (s *ConfigService) GetCache(cacheName string) (*CacheInfo, *Response, error
 // The caller must be a member of a group that is granted the Administrate Server capability.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#get-summary
-func (s *ConfigService) GetSummary(opt *SummaryOptions) (*SummaryInfo, *Response, error) {
+func (s *ConfigService) GetSummary(ctx context.Context, opt *SummaryOptions) (*SummaryInfo, *Response, error) {
 	u := "config/server/summary"
 
 	u, err := addOptions(u, opt)
@@ -342,7 +343,7 @@ func (s *ConfigService) GetSummary(opt *SummaryOptions) (*SummaryInfo, *Response
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -361,10 +362,10 @@ func (s *ConfigService) GetSummary(opt *SummaryOptions) (*SummaryInfo, *Response
 // The entries in the map are sorted by capability ID.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#list-capabilities
-func (s *ConfigService) ListCapabilities() (*map[string]ConfigCapabilityInfo, *Response, error) {
+func (s *ConfigService) ListCapabilities(ctx context.Context) (*map[string]ConfigCapabilityInfo, *Response, error) {
 	u := "config/server/capabilities"
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -392,10 +393,10 @@ func (s *ConfigService) ListCapabilities() (*map[string]ConfigCapabilityInfo, *R
 // The entries in the list are sorted by task state, remaining delay and command.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#list-tasks
-func (s *ConfigService) ListTasks() (*[]TaskInfo, *Response, error) {
+func (s *ConfigService) ListTasks(ctx context.Context) (*[]TaskInfo, *Response, error) {
 	u := "config/server/tasks"
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -419,10 +420,10 @@ func (s *ConfigService) ListTasks() (*[]TaskInfo, *Response, error) {
 // * Administrate Server
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#get-task
-func (s *ConfigService) GetTask(taskID string) (*TaskInfo, *Response, error) {
+func (s *ConfigService) GetTask(ctx context.Context, taskID string) (*TaskInfo, *Response, error) {
 	u := fmt.Sprintf("config/server/tasks/%s", taskID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -439,10 +440,10 @@ func (s *ConfigService) GetTask(taskID string) (*TaskInfo, *Response, error) {
 // GetTopMenus returns the list of additional top menu entries.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#get-top-menus
-func (s *ConfigService) GetTopMenus() (*[]TopMenuEntryInfo, *Response, error) {
+func (s *ConfigService) GetTopMenus(ctx context.Context) (*[]TopMenuEntryInfo, *Response, error) {
 	u := "config/server/top-menus"
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -463,10 +464,10 @@ func (s *ConfigService) GetTopMenus() (*[]TopMenuEntryInfo, *Response, error) {
 // If the token is invalid or if it’s the token of another user the request fails and the response is “422 Unprocessable Entity”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#confirm-email
-func (s *ConfigService) ConfirmEmail(input *EmailConfirmationInput) (*Response, error) {
+func (s *ConfigService) ConfirmEmail(ctx context.Context, input *EmailConfirmationInput) (*Response, error) {
 	u := "config/server/email.confirm"
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, err
 	}
@@ -477,10 +478,10 @@ func (s *ConfigService) ConfirmEmail(input *EmailConfirmationInput) (*Response, 
 // CacheOperations executes a cache operation that is specified in the request body in a CacheOperationInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#cache-operations
-func (s *ConfigService) CacheOperations(input *CacheOperationInput) (*Response, error) {
+func (s *ConfigService) CacheOperations(ctx context.Context, input *CacheOperationInput) (*Response, error) {
 	u := "config/server/caches/"
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, err
 	}
@@ -496,10 +497,10 @@ func (s *ConfigService) CacheOperations(input *CacheOperationInput) (*Response, 
 // * Administrate Server (any cache including "web_sessions")
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#flush-cache
-func (s *ConfigService) FlushCache(cacheName string, input *CacheOperationInput) (*Response, error) {
+func (s *ConfigService) FlushCache(ctx context.Context, cacheName string, input *CacheOperationInput) (*Response, error) {
 	u := fmt.Sprintf("config/server/caches/%s/flush", cacheName)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +524,7 @@ func (s *ConfigService) FlushCache(cacheName string, input *CacheOperationInput)
 // * Administrate Server
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#delete-task
-func (s *ConfigService) DeleteTask(taskID string) (*Response, error) {
+func (s *ConfigService) DeleteTask(ctx context.Context, taskID string) (*Response, error) {
 	u := fmt.Sprintf("config/server/tasks/%s", taskID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/andygrunwald/go-gerrit"
@@ -8,12 +9,13 @@ import (
 
 func ExampleConfigService_GetVersion() {
 	instance := "https://gerrit-review.googlesource.com/"
-	client, err := gerrit.NewClient(instance, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, instance, nil)
 	if err != nil {
 		panic(err)
 	}
 
-	v, _, err := client.Config.GetVersion()
+	v, _, err := client.Config.GetVersion(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/events.go
+++ b/events.go
@@ -2,6 +2,7 @@ package gerrit
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/url"
@@ -120,7 +121,7 @@ func (events *EventsLogService) getURL(options *EventsLogOptions) (string, error
 // unmarshalled into EventInfo.
 //
 // Gerrit API docs: https://<yourserver>/plugins/events-log/Documentation/rest-api-events.html
-func (events *EventsLogService) GetEvents(options *EventsLogOptions) ([]EventInfo, *Response, [][]byte, error) {
+func (events *EventsLogService) GetEvents(ctx context.Context, options *EventsLogOptions) ([]EventInfo, *Response, [][]byte, error) {
 	info := []EventInfo{}
 	failures := [][]byte{}
 	requestURL, err := events.getURL(options)
@@ -129,7 +130,7 @@ func (events *EventsLogService) GetEvents(options *EventsLogOptions) ([]EventInf
 		return info, nil, failures, err
 	}
 
-	request, err := events.client.NewRequest("GET", requestURL, nil)
+	request, err := events.client.NewRequest(ctx, "GET", requestURL, nil)
 	if err != nil {
 		return info, nil, failures, err
 	}

--- a/events_test.go
+++ b/events_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -30,7 +31,7 @@ func TestEventsLogService_GetEvents_NoDateRange(t *testing.T) {
 	})
 
 	options := &gerrit.EventsLogOptions{}
-	events, _, _, err := testClient.EventsLog.GetEvents(options)
+	events, _, _, err := testClient.EventsLog.GetEvents(context.Background(), options)
 	if err != nil {
 		t.Error(err)
 	}
@@ -80,7 +81,7 @@ func TestEventsLogService_GetEvents_DateRangeFromAndTo(t *testing.T) {
 	})
 
 	options := &gerrit.EventsLogOptions{From: from, To: to}
-	_, _, _, err := testClient.EventsLog.GetEvents(options)
+	_, _, _, err := testClient.EventsLog.GetEvents(context.Background(), options)
 	if err != nil {
 		t.Error(err)
 	}
@@ -111,7 +112,7 @@ func TestEventsLogService_GetEvents_DateRangeFromOnly(t *testing.T) {
 	})
 
 	options := &gerrit.EventsLogOptions{From: from}
-	_, _, _, err := testClient.EventsLog.GetEvents(options)
+	_, _, _, err := testClient.EventsLog.GetEvents(context.Background(), options)
 	if err != nil {
 		t.Error(err)
 	}
@@ -141,7 +142,7 @@ func TestEventsLogService_GetEvents_DateRangeToOnly(t *testing.T) {
 	})
 
 	options := &gerrit.EventsLogOptions{To: to}
-	_, _, _, err := testClient.EventsLog.GetEvents(options)
+	_, _, _, err := testClient.EventsLog.GetEvents(context.Background(), options)
 	if err != nil {
 		t.Error(err)
 	}
@@ -158,7 +159,7 @@ func TestEventsLogService_GetEvents_UnmarshalError(t *testing.T) {
 	})
 
 	options := &gerrit.EventsLogOptions{IgnoreUnmarshalErrors: true}
-	events, _, failures, err := testClient.EventsLog.GetEvents(options)
+	events, _, failures, err := testClient.EventsLog.GetEvents(context.Background(), options)
 	if err != nil {
 		t.Error(err)
 	}

--- a/examples/create_new_project/main.go
+++ b/examples/create_new_project/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/andygrunwald/go-gerrit"
@@ -8,7 +9,8 @@ import (
 
 func main() {
 	instance := fmt.Sprintf("http://%s:8080", "localhost")
-	client, err := gerrit.NewClient(instance, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, instance, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -28,7 +30,7 @@ func main() {
 		Branches:          []string{gerritBranch},
 		CreateEmptyCommit: true,
 	}
-	projectInfo, _, err := client.Projects.CreateProject(gerritProject, data)
+	projectInfo, _, err := client.Projects.CreateProject(ctx, gerritProject, data)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/get_changes/main.go
+++ b/examples/get_changes/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/andygrunwald/go-gerrit"
@@ -8,7 +9,8 @@ import (
 
 func main() {
 	instance := "https://android-review.googlesource.com/"
-	client, err := gerrit.NewClient(instance, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, instance, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -16,7 +18,7 @@ func main() {
 	opt := &gerrit.QueryChangeOptions{}
 	opt.Query = []string{"project:kernel/common"}
 	opt.AdditionalFields = []string{"LABELS"}
-	changes, _, err := client.Changes.QueryChanges(opt)
+	changes, _, err := client.Changes.QueryChanges(ctx, opt)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/get_gerrit_version/main.go
+++ b/examples/get_gerrit_version/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/andygrunwald/go-gerrit"
@@ -8,12 +9,13 @@ import (
 
 func main() {
 	instance := "https://gerrit-review.googlesource.com/"
-	client, err := gerrit.NewClient(instance, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, instance, nil)
 	if err != nil {
 		panic(err)
 	}
 
-	v, _, err := client.Config.GetVersion()
+	v, _, err := client.Config.GetVersion(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/get_public_projects/main.go
+++ b/examples/get_public_projects/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/andygrunwald/go-gerrit"
@@ -8,7 +9,8 @@ import (
 
 func main() {
 	instance := "https://chromium-review.googlesource.com/"
-	client, err := gerrit.NewClient(instance, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, instance, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -16,7 +18,7 @@ func main() {
 	opt := &gerrit.ProjectOptions{
 		Description: true,
 	}
-	projects, _, err := client.Projects.ListProjects(opt)
+	projects, _, err := client.Projects.ListProjects(ctx, opt)
 	if err != nil {
 		panic(err)
 	}

--- a/groups.go
+++ b/groups.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -89,7 +90,7 @@ type ListGroupsOptions struct {
 // The entries in the map are sorted by group name.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#list-groups
-func (s *GroupsService) ListGroups(opt *ListGroupsOptions) (*map[string]GroupInfo, *Response, error) {
+func (s *GroupsService) ListGroups(ctx context.Context, opt *ListGroupsOptions) (*map[string]GroupInfo, *Response, error) {
 	u := "groups/"
 
 	u, err := addOptions(u, opt)
@@ -97,7 +98,7 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions) (*map[string]GroupInf
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -114,22 +115,22 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions) (*map[string]GroupInf
 // GetGroup retrieves a group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#get-group
-func (s *GroupsService) GetGroup(groupID string) (*GroupInfo, *Response, error) {
+func (s *GroupsService) GetGroup(ctx context.Context, groupID string) (*GroupInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s", groupID)
-	return s.getGroupInfoResponse(u)
+	return s.getGroupInfoResponse(ctx, u)
 }
 
 // GetGroupDetail retrieves a group with the direct members and the directly included groups.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#get-group-detail
-func (s *GroupsService) GetGroupDetail(groupID string) (*GroupInfo, *Response, error) {
+func (s *GroupsService) GetGroupDetail(ctx context.Context, groupID string) (*GroupInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/detail", groupID)
-	return s.getGroupInfoResponse(u)
+	return s.getGroupInfoResponse(ctx, u)
 }
 
 // getGroupInfoResponse retrieved a single GroupInfo Response for a GET request
-func (s *GroupsService) getGroupInfoResponse(u string) (*GroupInfo, *Response, error) {
-	req, err := s.client.NewRequest("GET", u, nil)
+func (s *GroupsService) getGroupInfoResponse(ctx context.Context, u string) (*GroupInfo, *Response, error) {
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -146,26 +147,26 @@ func (s *GroupsService) getGroupInfoResponse(u string) (*GroupInfo, *Response, e
 // GetGroupName retrieves the name of a group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#get-group-name
-func (s *GroupsService) GetGroupName(groupID string) (string, *Response, error) {
+func (s *GroupsService) GetGroupName(ctx context.Context, groupID string) (string, *Response, error) {
 	u := fmt.Sprintf("groups/%s/name", groupID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // GetGroupDescription retrieves the description of a group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#get-group-description
-func (s *GroupsService) GetGroupDescription(groupID string) (string, *Response, error) {
+func (s *GroupsService) GetGroupDescription(ctx context.Context, groupID string) (string, *Response, error) {
 	u := fmt.Sprintf("groups/%s/description", groupID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // GetGroupOptions retrieves the options of a group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#get-group-options
-func (s *GroupsService) GetGroupOptions(groupID string) (*GroupOptionsInfo, *Response, error) {
+func (s *GroupsService) GetGroupOptions(ctx context.Context, groupID string) (*GroupOptionsInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/options", groupID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -182,10 +183,10 @@ func (s *GroupsService) GetGroupOptions(groupID string) (*GroupOptionsInfo, *Res
 // GetGroupOwner retrieves the owner group of a Gerrit internal group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#get-group-owner
-func (s *GroupsService) GetGroupOwner(groupID string) (*GroupInfo, *Response, error) {
+func (s *GroupsService) GetGroupOwner(ctx context.Context, groupID string) (*GroupInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/owner", groupID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -203,10 +204,10 @@ func (s *GroupsService) GetGroupOwner(groupID string) (*GroupInfo, *Response, er
 // The returned audit events are sorted by date in reverse order so that the newest audit event comes first.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#get-audit-log
-func (s *GroupsService) GetAuditLog(groupID string) (*[]GroupAuditEventInfo, *Response, error) {
+func (s *GroupsService) GetAuditLog(ctx context.Context, groupID string) (*[]GroupAuditEventInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/log.audit", groupID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -227,10 +228,10 @@ func (s *GroupsService) GetAuditLog(groupID string) (*[]GroupAuditEventInfo, *Re
 // If the group creation fails because the name is already in use the response is “409 Conflict”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#create-group
-func (s *GroupsService) CreateGroup(groupID string, input *GroupInput) (*GroupInfo, *Response, error) {
+func (s *GroupsService) CreateGroup(ctx context.Context, groupID string, input *GroupInput) (*GroupInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s", groupID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -251,7 +252,7 @@ func (s *GroupsService) CreateGroup(groupID string, input *GroupInput) (*GroupIn
 // If renaming the group fails because the new name is already in use the response is “409 Conflict”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#rename-group
-func (s *GroupsService) RenameGroup(groupID, name string) (*string, *Response, error) {
+func (s *GroupsService) RenameGroup(ctx context.Context, groupID, name string) (*string, *Response, error) {
 	u := fmt.Sprintf("groups/%s/name", groupID)
 	input := struct {
 		Name string `json:"name"`
@@ -259,7 +260,7 @@ func (s *GroupsService) RenameGroup(groupID, name string) (*string, *Response, e
 		Name: name,
 	}
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -280,7 +281,7 @@ func (s *GroupsService) RenameGroup(groupID, name string) (*string, *Response, e
 // If the description was deleted the response is “204 No Content”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#set-group-description
-func (s *GroupsService) SetGroupDescription(groupID, description string) (*string, *Response, error) {
+func (s *GroupsService) SetGroupDescription(ctx context.Context, groupID, description string) (*string, *Response, error) {
 	u := fmt.Sprintf("groups/%s/description", groupID)
 	input := struct {
 		Description string `json:"description"`
@@ -288,7 +289,7 @@ func (s *GroupsService) SetGroupDescription(groupID, description string) (*strin
 		Description: description,
 	}
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -305,9 +306,9 @@ func (s *GroupsService) SetGroupDescription(groupID, description string) (*strin
 // DeleteGroupDescription deletes the description of a Gerrit internal group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#delete-group-description
-func (s *GroupsService) DeleteGroupDescription(groupID string) (*Response, error) {
+func (s *GroupsService) DeleteGroupDescription(ctx context.Context, groupID string) (*Response, error) {
 	u := fmt.Sprintf("groups/%s/description", groupID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // SetGroupOptions sets the options of a Gerrit internal group.
@@ -316,10 +317,10 @@ func (s *GroupsService) DeleteGroupDescription(groupID string) (*Response, error
 // As response the new group options are returned as a GroupOptionsInfo entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#set-group-options
-func (s *GroupsService) SetGroupOptions(groupID string, input *GroupOptionsInput) (*GroupOptionsInfo, *Response, error) {
+func (s *GroupsService) SetGroupOptions(ctx context.Context, groupID string, input *GroupOptionsInput) (*GroupOptionsInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/options", groupID)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -338,7 +339,7 @@ func (s *GroupsService) SetGroupOptions(groupID string, input *GroupOptionsInput
 // The new owner can be specified by name, by group UUID or by the legacy numeric group ID.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#set-group-owner
-func (s *GroupsService) SetGroupOwner(groupID, owner string) (*GroupInfo, *Response, error) {
+func (s *GroupsService) SetGroupOwner(ctx context.Context, groupID, owner string) (*GroupInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/owner", groupID)
 	input := struct {
 		Owner string `json:"owner"`
@@ -346,7 +347,7 @@ func (s *GroupsService) SetGroupOwner(groupID, owner string) (*GroupInfo, *Respo
 		Owner: owner,
 	}
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/groups_include.go
+++ b/groups_include.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -8,10 +9,10 @@ import (
 // The entries in the list are sorted by group name and UUID.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#included-groups
-func (s *GroupsService) ListIncludedGroups(groupID string) (*[]GroupInfo, *Response, error) {
+func (s *GroupsService) ListIncludedGroups(ctx context.Context, groupID string) (*[]GroupInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/groups/", groupID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -28,10 +29,10 @@ func (s *GroupsService) ListIncludedGroups(groupID string) (*[]GroupInfo, *Respo
 // GetIncludedGroup retrieves an included group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#get-included-group
-func (s *GroupsService) GetIncludedGroup(groupID, includeGroupID string) (*GroupInfo, *Response, error) {
+func (s *GroupsService) GetIncludedGroup(ctx context.Context, groupID, includeGroupID string) (*GroupInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/groups/%s", groupID, includeGroupID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -52,10 +53,10 @@ func (s *GroupsService) GetIncludedGroup(groupID, includeGroupID string) (*Group
 // The request also succeeds if the group is already included in this group, but then the HTTP response code is 200 OK.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#include-group
-func (s *GroupsService) IncludeGroup(groupID, includeGroupID string) (*GroupInfo, *Response, error) {
+func (s *GroupsService) IncludeGroup(ctx context.Context, groupID, includeGroupID string) (*GroupInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/groups/%s", groupID, includeGroupID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,10 +77,10 @@ func (s *GroupsService) IncludeGroup(groupID, includeGroupID string) (*GroupInfo
 // A GroupInfo entity is returned for each group specified in the input, independently of whether the group was newly included into the group or whether the group was already included in the group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#include-groups
-func (s *GroupsService) IncludeGroups(groupID string, input *GroupsInput) (*[]GroupInfo, *Response, error) {
+func (s *GroupsService) IncludeGroups(ctx context.Context, groupID string, input *GroupsInput) (*[]GroupInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/groups", groupID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -96,19 +97,19 @@ func (s *GroupsService) IncludeGroups(groupID string, input *GroupsInput) (*[]Gr
 // DeleteIncludedGroup deletes an included group from a Gerrit internal group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#include-group
-func (s *GroupsService) DeleteIncludedGroup(groupID, includeGroupID string) (*Response, error) {
+func (s *GroupsService) DeleteIncludedGroup(ctx context.Context, groupID, includeGroupID string) (*Response, error) {
 	u := fmt.Sprintf("groups/%s/groups/%s", groupID, includeGroupID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteIncludedGroups delete one or several included groups from a Gerrit internal group.
 // The groups to be deleted from the group must be provided in the request body as a GroupsInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#delete-included-groups
-func (s *GroupsService) DeleteIncludedGroups(groupID string, input *GroupsInput) (*Response, error) {
+func (s *GroupsService) DeleteIncludedGroups(ctx context.Context, groupID string, input *GroupsInput) (*Response, error) {
 	u := fmt.Sprintf("groups/%s/groups.delete", groupID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, err
 	}

--- a/groups_member.go
+++ b/groups_member.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -23,7 +24,7 @@ type MembersInput struct {
 // The entries in the list are sorted by full name, preferred email and id.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#group-members
-func (s *GroupsService) ListGroupMembers(groupID string, opt *ListGroupMembersOptions) (*[]AccountInfo, *Response, error) {
+func (s *GroupsService) ListGroupMembers(ctx context.Context, groupID string, opt *ListGroupMembersOptions) (*[]AccountInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/members/", groupID)
 
 	u, err := addOptions(u, opt)
@@ -31,7 +32,7 @@ func (s *GroupsService) ListGroupMembers(groupID string, opt *ListGroupMembersOp
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -48,10 +49,10 @@ func (s *GroupsService) ListGroupMembers(groupID string, opt *ListGroupMembersOp
 // GetGroupMember retrieves a group member.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#get-group-member
-func (s *GroupsService) GetGroupMember(groupID, accountID string) (*AccountInfo, *Response, error) {
+func (s *GroupsService) GetGroupMember(ctx context.Context, groupID, accountID string) (*AccountInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/members/%s", groupID, accountID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -68,10 +69,10 @@ func (s *GroupsService) GetGroupMember(groupID, accountID string) (*AccountInfo,
 // AddGroupMember adds a user as member to a Gerrit internal group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#add-group-member
-func (s *GroupsService) AddGroupMember(groupID, accountID string) (*AccountInfo, *Response, error) {
+func (s *GroupsService) AddGroupMember(ctx context.Context, groupID, accountID string) (*AccountInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/members/%s", groupID, accountID)
 
-	req, err := s.client.NewRequest("PUT", u, nil)
+	req, err := s.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,10 +93,10 @@ func (s *GroupsService) AddGroupMember(groupID, accountID string) (*AccountInfo,
 // An AccountInfo entity is returned for each user specified in the input, independently of whether the user was newly added to the group or whether the user was already a member of the group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#_add_group_members
-func (s *GroupsService) AddGroupMembers(groupID string, input *MembersInput) (*[]AccountInfo, *Response, error) {
+func (s *GroupsService) AddGroupMembers(ctx context.Context, groupID string, input *MembersInput) (*[]AccountInfo, *Response, error) {
 	u := fmt.Sprintf("groups/%s/members", groupID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,19 +113,19 @@ func (s *GroupsService) AddGroupMembers(groupID string, input *MembersInput) (*[
 // DeleteGroupMember deletes a user from a Gerrit internal group.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#delete-group-member
-func (s *GroupsService) DeleteGroupMember(groupID, accountID string) (*Response, error) {
+func (s *GroupsService) DeleteGroupMember(ctx context.Context, groupID, accountID string) (*Response, error) {
 	u := fmt.Sprintf("groups/%s/members/%s", groupID, accountID)
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteGroupMembers delete one or several users from a Gerrit internal group.
 // The users to be deleted from the group must be provided in the request body as a MembersInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-groups.html#delete-group-members
-func (s *GroupsService) DeleteGroupMembers(groupID string, input *MembersInput) (*Response, error) {
+func (s *GroupsService) DeleteGroupMembers(ctx context.Context, groupID string, input *MembersInput) (*Response, error) {
 	u := fmt.Sprintf("groups/%s/members.delete", groupID)
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins.go
+++ b/plugins.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -39,7 +40,7 @@ type PluginOptions struct {
 // The entries in the map are sorted by plugin ID.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-plugins.html#list-plugins
-func (s *PluginsService) ListPlugins(opt *PluginOptions) (*map[string]PluginInfo, *Response, error) {
+func (s *PluginsService) ListPlugins(ctx context.Context, opt *PluginOptions) (*map[string]PluginInfo, *Response, error) {
 	u := "plugins/"
 
 	u, err := addOptions(u, opt)
@@ -47,7 +48,7 @@ func (s *PluginsService) ListPlugins(opt *PluginOptions) (*map[string]PluginInfo
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -64,9 +65,9 @@ func (s *PluginsService) ListPlugins(opt *PluginOptions) (*map[string]PluginInfo
 // GetPluginStatus retrieves the status of a plugin on the Gerrit server.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-plugins.html#get-plugin-status
-func (s *PluginsService) GetPluginStatus(pluginID string) (*PluginInfo, *Response, error) {
+func (s *PluginsService) GetPluginStatus(ctx context.Context, pluginID string) (*PluginInfo, *Response, error) {
 	u := fmt.Sprintf("plugins/%s/gerrit~status", pluginID)
-	return s.requestWithPluginInfoResponse("GET", u, nil)
+	return s.requestWithPluginInfoResponse(ctx, "GET", u, nil)
 }
 
 // InstallPlugin installs a new plugin on the Gerrit server.
@@ -80,9 +81,9 @@ func (s *PluginsService) GetPluginStatus(pluginID string) (*PluginInfo, *Respons
 // If an existing plugin was overwritten the response is “200 OK”.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#set-dashboard
-func (s *PluginsService) InstallPlugin(pluginID string, input *PluginInput) (*PluginInfo, *Response, error) {
+func (s *PluginsService) InstallPlugin(ctx context.Context, pluginID string, input *PluginInput) (*PluginInfo, *Response, error) {
 	u := fmt.Sprintf("plugins/%s", pluginID)
-	return s.requestWithPluginInfoResponse("PUT", u, input)
+	return s.requestWithPluginInfoResponse(ctx, "PUT", u, input)
 }
 
 // EnablePlugin enables a plugin on the Gerrit server.
@@ -90,9 +91,9 @@ func (s *PluginsService) InstallPlugin(pluginID string, input *PluginInput) (*Pl
 // As response a PluginInfo entity is returned that describes the plugin.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-plugins.html#enable-plugin
-func (s *PluginsService) EnablePlugin(pluginID string) (*PluginInfo, *Response, error) {
+func (s *PluginsService) EnablePlugin(ctx context.Context, pluginID string) (*PluginInfo, *Response, error) {
 	u := fmt.Sprintf("plugins/%s/gerrit~enable", pluginID)
-	return s.requestWithPluginInfoResponse("POST", u, nil)
+	return s.requestWithPluginInfoResponse(ctx, "POST", u, nil)
 }
 
 // DisablePlugin disables a plugin on the Gerrit server.
@@ -100,9 +101,9 @@ func (s *PluginsService) EnablePlugin(pluginID string) (*PluginInfo, *Response, 
 // As response a PluginInfo entity is returned that describes the plugin.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-plugins.html#disable-plugin
-func (s *PluginsService) DisablePlugin(pluginID string) (*PluginInfo, *Response, error) {
+func (s *PluginsService) DisablePlugin(ctx context.Context, pluginID string) (*PluginInfo, *Response, error) {
 	u := fmt.Sprintf("plugins/%s/gerrit~disable", pluginID)
-	return s.requestWithPluginInfoResponse("POST", u, nil)
+	return s.requestWithPluginInfoResponse(ctx, "POST", u, nil)
 }
 
 // ReloadPlugin reloads a plugin on the Gerrit server.
@@ -110,13 +111,13 @@ func (s *PluginsService) DisablePlugin(pluginID string) (*PluginInfo, *Response,
 // As response a PluginInfo entity is returned that describes the plugin.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-plugins.html#disable-plugin
-func (s *PluginsService) ReloadPlugin(pluginID string) (*PluginInfo, *Response, error) {
+func (s *PluginsService) ReloadPlugin(ctx context.Context, pluginID string) (*PluginInfo, *Response, error) {
 	u := fmt.Sprintf("plugins/%s/gerrit~reload", pluginID)
-	return s.requestWithPluginInfoResponse("POST", u, nil)
+	return s.requestWithPluginInfoResponse(ctx, "POST", u, nil)
 }
 
-func (s *PluginsService) requestWithPluginInfoResponse(method, u string, input interface{}) (*PluginInfo, *Response, error) {
-	req, err := s.client.NewRequest(method, u, input)
+func (s *PluginsService) requestWithPluginInfoResponse(ctx context.Context, method, u string, input interface{}) (*PluginInfo, *Response, error) {
+	req, err := s.client.NewRequest(ctx, method, u, input)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/projects.go
+++ b/projects.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -217,7 +218,7 @@ type ProjectOptions struct {
 // The entries in the map are sorted by project name.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#list-projects
-func (s *ProjectsService) ListProjects(opt *ProjectOptions) (*map[string]ProjectInfo, *Response, error) {
+func (s *ProjectsService) ListProjects(ctx context.Context, opt *ProjectOptions) (*map[string]ProjectInfo, *Response, error) {
 	u := "projects/"
 
 	u, err := addOptions(u, opt)
@@ -226,29 +227,29 @@ func (s *ProjectsService) ListProjects(opt *ProjectOptions) (*map[string]Project
 	}
 
 	v := new(map[string]ProjectInfo)
-	resp, err := s.client.Call("GET", u, nil, v)
+	resp, err := s.client.Call(ctx, "GET", u, nil, v)
 	return v, resp, err
 }
 
 // GetProject retrieves a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-project
-func (s *ProjectsService) GetProject(projectName string) (*ProjectInfo, *Response, error) {
+func (s *ProjectsService) GetProject(ctx context.Context, projectName string) (*ProjectInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s", url.QueryEscape(projectName))
 
 	v := new(ProjectInfo)
-	resp, err := s.client.Call("GET", u, nil, v)
+	resp, err := s.client.Call(ctx, "GET", u, nil, v)
 	return v, resp, err
 }
 
 // CreateProject creates a new project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#create-project
-func (s *ProjectsService) CreateProject(projectName string, input *ProjectInput) (*ProjectInfo, *Response, error) {
+func (s *ProjectsService) CreateProject(ctx context.Context, projectName string, input *ProjectInput) (*ProjectInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/", url.QueryEscape(projectName))
 
 	v := new(ProjectInfo)
-	resp, err := s.client.Call("PUT", u, input, v)
+	resp, err := s.client.Call(ctx, "PUT", u, input, v)
 	return v, resp, err
 }
 
@@ -257,45 +258,45 @@ func (s *ProjectsService) CreateProject(projectName string, input *ProjectInput)
 // Note: requires installation of delete-project plugin
 //
 // Gerrit API docs: https://gerrit.googlesource.com/plugins/delete-project/+/refs/heads/master/src/main/resources/Documentation/rest-api-projects.md
-func (s *ProjectsService) DeleteProject(projectName string, input *DeleteOptionsInfo) (*Response, error) {
+func (s *ProjectsService) DeleteProject(ctx context.Context, projectName string, input *DeleteOptionsInfo) (*Response, error) {
 	u := fmt.Sprintf("projects/%s", projectName)
 
-	return s.client.DeleteRequest(u, input)
+	return s.client.DeleteRequest(ctx, u, input)
 }
 
 // GetProjectDescription retrieves the description of a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-project-description
-func (s *ProjectsService) GetProjectDescription(projectName string) (string, *Response, error) {
+func (s *ProjectsService) GetProjectDescription(ctx context.Context, projectName string) (string, *Response, error) {
 	u := fmt.Sprintf("projects/%s/description", url.QueryEscape(projectName))
 
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // GetProjectParent retrieves the name of a project’s parent project.
 // For the All-Projects root project an empty string is returned.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-project-parent
-func (s *ProjectsService) GetProjectParent(projectName string) (string, *Response, error) {
+func (s *ProjectsService) GetProjectParent(ctx context.Context, projectName string) (string, *Response, error) {
 	u := fmt.Sprintf("projects/%s/parent", url.QueryEscape(projectName))
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // GetHEAD retrieves for a project the name of the branch to which HEAD points.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-head
-func (s *ProjectsService) GetHEAD(projectName string) (string, *Response, error) {
+func (s *ProjectsService) GetHEAD(ctx context.Context, projectName string) (string, *Response, error) {
 	u := fmt.Sprintf("projects/%s/HEAD", url.QueryEscape(projectName))
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }
 
 // GetRepositoryStatistics return statistics for the repository of a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-repository-statistics
-func (s *ProjectsService) GetRepositoryStatistics(projectName string) (*RepositoryStatisticsInfo, *Response, error) {
+func (s *ProjectsService) GetRepositoryStatistics(ctx context.Context, projectName string) (*RepositoryStatisticsInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/statistics.git", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -314,10 +315,10 @@ func (s *ProjectsService) GetRepositoryStatistics(projectName string) (*Reposito
 // it generally contains fields that may have been inherited from parent projects.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-config
-func (s *ProjectsService) GetConfig(projectName string) (*ConfigInfo, *Response, error) {
+func (s *ProjectsService) GetConfig(ctx context.Context, projectName string) (*ConfigInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/config", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -335,12 +336,12 @@ func (s *ProjectsService) GetConfig(projectName string) (*ConfigInfo, *Response,
 // The new project description must be provided in the request body inside a ProjectDescriptionInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#set-project-description
-func (s *ProjectsService) SetProjectDescription(projectName string, input *ProjectDescriptionInput) (*string, *Response, error) {
+func (s *ProjectsService) SetProjectDescription(ctx context.Context, projectName string, input *ProjectDescriptionInput) (*string, *Response, error) {
 	u := fmt.Sprintf("projects/%s/description", url.QueryEscape(projectName))
 
 	// TODO Use here the getStringResponseWithoutOptions (for PUT requests)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -361,9 +362,9 @@ func (s *ProjectsService) SetProjectDescription(projectName string, input *Proje
 // In this case, if you want to specify a commit message, use PUT to delete the description.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#delete-project-description
-func (s *ProjectsService) DeleteProjectDescription(projectName string) (*Response, error) {
+func (s *ProjectsService) DeleteProjectDescription(ctx context.Context, projectName string) (*Response, error) {
 	u := fmt.Sprintf("projects/%s/description", url.QueryEscape(projectName))
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // BanCommit marks commits as banned for the project.
@@ -377,10 +378,10 @@ func (s *ProjectsService) DeleteProjectDescription(projectName string) (*Respons
 // The caller must be project owner.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#ban-commit
-func (s *ProjectsService) BanCommit(projectName string, input *BanInput) (*BanResultInfo, *Response, error) {
+func (s *ProjectsService) BanCommit(ctx context.Context, projectName string, input *BanInput) (*BanResultInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/ban", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -398,10 +399,10 @@ func (s *ProjectsService) BanCommit(projectName string, input *BanInput) (*BanRe
 // The new configuration must be provided in the request body as a ConfigInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#set-config
-func (s *ProjectsService) SetConfig(projectName string, input *ConfigInput) (*ConfigInfo, *Response, error) {
+func (s *ProjectsService) SetConfig(ctx context.Context, projectName string, input *ConfigInput) (*ConfigInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/config", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -419,12 +420,12 @@ func (s *ProjectsService) SetConfig(projectName string, input *ConfigInput) (*Co
 // The new ref to which HEAD should point must be provided in the request body inside a HeadInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#set-head
-func (s *ProjectsService) SetHEAD(projectName string, input *HeadInput) (*string, *Response, error) {
+func (s *ProjectsService) SetHEAD(ctx context.Context, projectName string, input *HeadInput) (*string, *Response, error) {
 	u := fmt.Sprintf("projects/%s/HEAD", url.QueryEscape(projectName))
 
 	// TODO Use here the getStringResponseWithoutOptions (for PUT requests)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -442,12 +443,12 @@ func (s *ProjectsService) SetHEAD(projectName string, input *HeadInput) (*string
 // The new name of the parent project must be provided in the request body inside a ProjectParentInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#set-project-parent
-func (s *ProjectsService) SetProjectParent(projectName string, input *ProjectParentInput) (*string, *Response, error) {
+func (s *ProjectsService) SetProjectParent(ctx context.Context, projectName string, input *ProjectParentInput) (*string, *Response, error) {
 	u := fmt.Sprintf("projects/%s/parent", url.QueryEscape(projectName))
 
 	// TODO Use here the getStringResponseWithoutOptions (for PUT requests)
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -465,10 +466,10 @@ func (s *ProjectsService) SetProjectParent(projectName string, input *ProjectPar
 // The response is the streamed output of the garbage collection.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#run-gc
-func (s *ProjectsService) RunGC(projectName string, input *GCInput) (*Response, error) {
+func (s *ProjectsService) RunGC(ctx context.Context, projectName string, input *GCInput) (*Response, error) {
 	u := fmt.Sprintf("projects/%s/gc", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, err
 	}

--- a/projects_access.go
+++ b/projects_access.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -48,10 +49,10 @@ type CheckAccessOptions struct {
 // ListAccessRights lists the access rights for a single project
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-access
-func (s *ProjectsService) ListAccessRights(projectName string) (*ProjectAccessInfo, *Response, error) {
+func (s *ProjectsService) ListAccessRights(ctx context.Context, projectName string) (*ProjectAccessInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/access", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -80,10 +81,10 @@ func (s *ProjectsService) ListAccessRights(projectName string) (*ProjectAccessIn
 // After removals have been applied, additions will be applied.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#set-access
-func (s *ProjectsService) AddUpdateDeleteAccessRights(projectName string, input *ProjectAccessInput) (*ProjectAccessInfo, *Response, error) {
+func (s *ProjectsService) AddUpdateDeleteAccessRights(ctx context.Context, projectName string, input *ProjectAccessInput) (*ProjectAccessInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/access", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,10 +104,10 @@ func (s *ProjectsService) AddUpdateDeleteAccessRights(projectName string, input 
 // Like Create Change, it returns a ChangeInfo entity describing the resulting change.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#create-access-change
-func (s *ProjectsService) CreateAccessRightChange(projectName string, input *ProjectAccessInput) (*ChangeInfo, *Response, error) {
+func (s *ProjectsService) CreateAccessRightChange(ctx context.Context, projectName string, input *ProjectAccessInput) (*ChangeInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/access:review", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -125,7 +126,7 @@ func (s *ProjectsService) CreateAccessRightChange(projectName string, input *Pro
 // The result is a AccessCheckInfo entity detailing the access of the given user for the given project, project-ref, or project-permission-ref combination.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#check-access
-func (s *ProjectsService) CheckAccess(projectName string, opt *CheckAccessOptions) (*AccessCheckInfo, *Response, error) {
+func (s *ProjectsService) CheckAccess(ctx context.Context, projectName string, opt *CheckAccessOptions) (*AccessCheckInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/check.access", url.QueryEscape(projectName))
 
 	u, err := addOptions(u, opt)
@@ -133,7 +134,7 @@ func (s *ProjectsService) CheckAccess(projectName string, opt *CheckAccessOption
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/projects_access_test.go
+++ b/projects_access_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -21,7 +22,7 @@ func TestProjectsService_ListAccessRights(t *testing.T) {
 		_, _ = fmt.Fprint(w, `)]}'`+"\n"+resp)
 	})
 
-	projectAccessRight, _, err := testClient.Projects.ListAccessRights("MyProject")
+	projectAccessRight, _, err := testClient.Projects.ListAccessRights(context.Background(), "MyProject")
 	if err != nil {
 		t.Errorf("project: list access rights error: %s", err)
 	}
@@ -47,7 +48,7 @@ func TestProjectsService_AddUpdateDeleteAccessRights(t *testing.T) {
 		t.Errorf("project: add/update/delete access right request params error: %s", err)
 	}
 
-	projectAccessRight, _, err := testClient.Projects.AddUpdateDeleteAccessRights("MyProject", req)
+	projectAccessRight, _, err := testClient.Projects.AddUpdateDeleteAccessRights(context.Background(), "MyProject", req)
 	if err != nil {
 		t.Errorf("project: add/update/delete access right error: %s", err)
 	}
@@ -78,7 +79,7 @@ func TestProjectsService_AccessCheck(t *testing.T) {
 		t.Errorf("project: access check request params error: %s", err)
 	}
 
-	accessCheckInfo, _, err := testClient.Projects.CheckAccess("MyProject", req)
+	accessCheckInfo, _, err := testClient.Projects.CheckAccess(context.Background(), "MyProject", req)
 	if err != nil {
 		t.Errorf("project: access check error: %s", err)
 	}
@@ -104,7 +105,7 @@ func TestProjectsService_CreateAccessChange(t *testing.T) {
 		t.Errorf("project: create access change request params error: %s", err)
 	}
 
-	changeInfo, _, err := testClient.Projects.CreateAccessRightChange("MyProject", req)
+	changeInfo, _, err := testClient.Projects.CreateAccessRightChange(context.Background(), "MyProject", req)
 	if err != nil {
 		t.Errorf("project: create access change error: %s", err)
 	}

--- a/projects_branch.go
+++ b/projects_branch.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -46,7 +47,7 @@ type BranchOptions struct {
 // ListBranches list the branches of a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#list-branches
-func (s *ProjectsService) ListBranches(projectName string, opt *BranchOptions) (*[]BranchInfo, *Response, error) {
+func (s *ProjectsService) ListBranches(ctx context.Context, projectName string, opt *BranchOptions) (*[]BranchInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/branches/", url.QueryEscape(projectName))
 
 	u, err := addOptions(u, opt)
@@ -54,7 +55,7 @@ func (s *ProjectsService) ListBranches(projectName string, opt *BranchOptions) (
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -71,10 +72,10 @@ func (s *ProjectsService) ListBranches(projectName string, opt *BranchOptions) (
 // GetBranch retrieves a branch of a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-branch
-func (s *ProjectsService) GetBranch(projectName, branchID string) (*BranchInfo, *Response, error) {
+func (s *ProjectsService) GetBranch(ctx context.Context, projectName, branchID string) (*BranchInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/branches/%s", url.QueryEscape(projectName), url.QueryEscape(branchID))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,10 +93,10 @@ func (s *ProjectsService) GetBranch(projectName, branchID string) (*BranchInfo, 
 // The caller must be project owner.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-reflog
-func (s *ProjectsService) GetReflog(projectName, branchID string) (*[]ReflogEntryInfo, *Response, error) {
+func (s *ProjectsService) GetReflog(ctx context.Context, projectName, branchID string) (*[]ReflogEntryInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/branches/%s/reflog", url.QueryEscape(projectName), url.QueryEscape(branchID))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -113,10 +114,10 @@ func (s *ProjectsService) GetReflog(projectName, branchID string) (*[]ReflogEntr
 // In the request body additional data for the branch can be provided as BranchInput.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#create-branch
-func (s *ProjectsService) CreateBranch(projectName, branchID string, input *BranchInput) (*BranchInfo, *Response, error) {
+func (s *ProjectsService) CreateBranch(ctx context.Context, projectName, branchID string, input *BranchInput) (*BranchInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/branches/%s", url.QueryEscape(projectName), url.QueryEscape(branchID))
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,25 +134,25 @@ func (s *ProjectsService) CreateBranch(projectName, branchID string, input *Bran
 // DeleteBranch deletes a branch.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#delete-branch
-func (s *ProjectsService) DeleteBranch(projectName, branchID string) (*Response, error) {
+func (s *ProjectsService) DeleteBranch(ctx context.Context, projectName, branchID string) (*Response, error) {
 	u := fmt.Sprintf("projects/%s/branches/%s", url.QueryEscape(projectName), url.QueryEscape(branchID))
-	return s.client.DeleteRequest(u, nil)
+	return s.client.DeleteRequest(ctx, u, nil)
 }
 
 // DeleteBranches delete one or more branches.
 // If some branches could not be deleted, the response is “409 Conflict” and the error message is contained in the response body.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#delete-branches
-func (s *ProjectsService) DeleteBranches(projectName string, input *DeleteBranchesInput) (*Response, error) {
+func (s *ProjectsService) DeleteBranches(ctx context.Context, projectName string, input *DeleteBranchesInput) (*Response, error) {
 	u := fmt.Sprintf("projects/%s/branches:delete", url.QueryEscape(projectName))
-	return s.client.DeleteRequest(u, input)
+	return s.client.DeleteRequest(ctx, u, input)
 }
 
 // GetBranchContent gets the content of a file from the HEAD revision of a certain branch.
 // The content is returned as base64 encoded string.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-content
-func (s *ProjectsService) GetBranchContent(projectName, branchID, fileID string) (string, *Response, error) {
+func (s *ProjectsService) GetBranchContent(ctx context.Context, projectName, branchID, fileID string) (string, *Response, error) {
 	u := fmt.Sprintf("projects/%s/branches/%s/files/%s/content", url.QueryEscape(projectName), url.QueryEscape(branchID), fileID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }

--- a/projects_childproject.go
+++ b/projects_childproject.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -17,7 +18,7 @@ type ChildProjectOptions struct {
 // ListChildProjects lists the direct child projects of a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#list-child-projects
-func (s *ProjectsService) ListChildProjects(projectName string, opt *ChildProjectOptions) (*[]ProjectInfo, *Response, error) {
+func (s *ProjectsService) ListChildProjects(ctx context.Context, projectName string, opt *ChildProjectOptions) (*[]ProjectInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/children/", url.QueryEscape(projectName))
 
 	u, err := addOptions(u, opt)
@@ -25,7 +26,7 @@ func (s *ProjectsService) ListChildProjects(projectName string, opt *ChildProjec
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -43,7 +44,7 @@ func (s *ProjectsService) ListChildProjects(projectName string, opt *ChildProjec
 // If a non-direct child project should be retrieved the parameter recursive must be set.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-child-project
-func (s *ProjectsService) GetChildProject(projectName, childProjectName string, opt *ChildProjectOptions) (*ProjectInfo, *Response, error) {
+func (s *ProjectsService) GetChildProject(ctx context.Context, projectName, childProjectName string, opt *ChildProjectOptions) (*ProjectInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/children/%s", url.QueryEscape(projectName), url.QueryEscape(childProjectName))
 
 	u, err := addOptions(u, opt)
@@ -51,7 +52,7 @@ func (s *ProjectsService) GetChildProject(projectName, childProjectName string, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/projects_commit.go
+++ b/projects_commit.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -9,10 +10,10 @@ import (
 // The commit must be visible to the caller.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-commit
-func (s *ProjectsService) GetCommit(projectName, commitID string) (*CommitInfo, *Response, error) {
+func (s *ProjectsService) GetCommit(ctx context.Context, projectName, commitID string) (*CommitInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/commits/%s", url.QueryEscape(projectName), commitID)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -30,9 +31,9 @@ func (s *ProjectsService) GetCommit(projectName, commitID string) (*CommitInfo, 
 // Branches that are not visible to the calling user according to the project’s read permissions are filtered out from the result.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-included-in
-func (s *ProjectsService) GetIncludeIn(projectName, commitID string) (*IncludedInInfo, *Response, error) {
+func (s *ProjectsService) GetIncludeIn(ctx context.Context, projectName, commitID string) (*IncludedInInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/commits/%s/in", url.QueryEscape((projectName)), commitID)
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -49,7 +50,7 @@ func (s *ProjectsService) GetIncludeIn(projectName, commitID string) (*IncludedI
 // The content is returned as base64 encoded string.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html##get-content-from-commit
-func (s *ProjectsService) GetCommitContent(projectName, commitID, fileID string) (string, *Response, error) {
+func (s *ProjectsService) GetCommitContent(ctx context.Context, projectName, commitID, fileID string) (string, *Response, error) {
 	u := fmt.Sprintf("projects/%s/commits/%s/files/%s/content", url.QueryEscape(projectName), commitID, fileID)
-	return getStringResponseWithoutOptions(s.client, u)
+	return getStringResponseWithoutOptions(ctx, s.client, u)
 }

--- a/projects_commit_test.go
+++ b/projects_commit_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -19,7 +20,7 @@ func TestProjectsService_GetIncludeIn(t *testing.T) {
 		fmt.Fprint(w, `)]}'`+"\n"+`{"branches": ["master"],"tags": ["1.1.0"]}`)
 	})
 
-	includedInInfo, _, err := testClient.Projects.GetIncludeIn("swift", "a8a477efffbbf3b44169bb9a1d3a334cbbd9aa96")
+	includedInInfo, _, err := testClient.Projects.GetIncludeIn(context.Background(), "swift", "a8a477efffbbf3b44169bb9a1d3a334cbbd9aa96")
 	if err != nil {
 		t.Errorf("Projects.GetIncludeIn returned error: %v", err)
 	}

--- a/projects_dashboard.go
+++ b/projects_dashboard.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -35,10 +36,10 @@ type DashboardInfo struct {
 // ListDashboards list custom dashboards for a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#list-dashboards
-func (s *ProjectsService) ListDashboards(projectName string) (*[]DashboardInfo, *Response, error) {
+func (s *ProjectsService) ListDashboards(ctx context.Context, projectName string) (*[]DashboardInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/dashboards/", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -55,10 +56,10 @@ func (s *ProjectsService) ListDashboards(projectName string) (*[]DashboardInfo, 
 // GetDashboard list custom dashboards for a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-dashboard
-func (s *ProjectsService) GetDashboard(projectName, dashboardName string) (*DashboardInfo, *Response, error) {
+func (s *ProjectsService) GetDashboard(ctx context.Context, projectName, dashboardName string) (*DashboardInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/dashboards/%s", url.QueryEscape(projectName), url.QueryEscape(dashboardName))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -78,10 +79,10 @@ func (s *ProjectsService) GetDashboard(projectName, dashboardName string) (*Dash
 // The creation/update information for the dashboard must be provided in the request body as a DashboardInput entity.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#set-dashboard
-func (s *ProjectsService) SetDashboard(projectName, dashboardID string, input *DashboardInput) (*DashboardInfo, *Response, error) {
+func (s *ProjectsService) SetDashboard(ctx context.Context, projectName, dashboardID string, input *DashboardInput) (*DashboardInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/dashboards/%s", url.QueryEscape(projectName), url.QueryEscape(dashboardID))
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,7 +103,7 @@ func (s *ProjectsService) SetDashboard(projectName, dashboardID string, input *D
 // Please note that some proxies prohibit request bodies for DELETE requests.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#delete-dashboard
-func (s *ProjectsService) DeleteDashboard(projectName, dashboardID string, input *DashboardInput) (*Response, error) {
+func (s *ProjectsService) DeleteDashboard(ctx context.Context, projectName, dashboardID string, input *DashboardInput) (*Response, error) {
 	u := fmt.Sprintf("projects/%s/dashboards/%s", url.QueryEscape(projectName), url.QueryEscape(dashboardID))
-	return s.client.DeleteRequest(u, input)
+	return s.client.DeleteRequest(ctx, u, input)
 }

--- a/projects_tag.go
+++ b/projects_tag.go
@@ -1,6 +1,7 @@
 package gerrit
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -30,14 +31,14 @@ type DeleteTagsInput struct {
 // ListTags list the tags of a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#list-tags
-func (s *ProjectsService) ListTags(projectName string, opt *ProjectBaseOptions) (*[]TagInfo, *Response, error) {
+func (s *ProjectsService) ListTags(ctx context.Context, projectName string, opt *ProjectBaseOptions) (*[]TagInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/tags/", url.QueryEscape(projectName))
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -54,10 +55,10 @@ func (s *ProjectsService) ListTags(projectName string, opt *ProjectBaseOptions) 
 // GetTag retrieves a tag of a project.
 //
 // Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-tag
-func (s *ProjectsService) GetTag(projectName, tagName string) (*TagInfo, *Response, error) {
+func (s *ProjectsService) GetTag(ctx context.Context, projectName, tagName string) (*TagInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/tags/%s", url.QueryEscape(projectName), url.QueryEscape(tagName))
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -74,10 +75,10 @@ func (s *ProjectsService) GetTag(projectName, tagName string) (*TagInfo, *Respon
 // CreateTag create a tag of a project
 //
 // Gerrit API docs:https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#create-tag
-func (s *ProjectsService) CreateTag(projectName, tagName string, input *TagInput) (*TagInfo, *Response, error) {
+func (s *ProjectsService) CreateTag(ctx context.Context, projectName, tagName string, input *TagInput) (*TagInfo, *Response, error) {
 	u := fmt.Sprintf("projects/%s/tags/%s", url.QueryEscape(projectName), url.QueryEscape(tagName))
 
-	req, err := s.client.NewRequest("PUT", u, input)
+	req, err := s.client.NewRequest(ctx, "PUT", u, input)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -94,10 +95,10 @@ func (s *ProjectsService) CreateTag(projectName, tagName string, input *TagInput
 // DeleteTag delete a tag of a project
 //
 // Gerrit API docs:https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#delete-tag
-func (s *ProjectsService) DeleteTag(projectName, tagName string) (*Response, error) {
+func (s *ProjectsService) DeleteTag(ctx context.Context, projectName, tagName string) (*Response, error) {
 	u := fmt.Sprintf("projects/%s/tags/%s", url.QueryEscape(projectName), url.QueryEscape(tagName))
 
-	req, err := s.client.NewRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -110,10 +111,10 @@ func (s *ProjectsService) DeleteTag(projectName, tagName string) (*Response, err
 // DeleteTags delete tags of a project
 //
 // Gerrit API docs:https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#delete-tags
-func (s *ProjectsService) DeleteTags(projectName string, input *DeleteTagsInput) (*Response, error) {
+func (s *ProjectsService) DeleteTags(ctx context.Context, projectName string, input *DeleteTagsInput) (*Response, error) {
 	u := fmt.Sprintf("projects/%s/tags:delete", url.QueryEscape(projectName))
 
-	req, err := s.client.NewRequest("POST", u, input)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
 	if err != nil {
 		return nil, err
 	}

--- a/projects_tag_test.go
+++ b/projects_tag_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -36,7 +37,7 @@ func TestProjectsService_CreateTag(t *testing.T) {
 		fmt.Fprint(w, `)]}'`+"\n"+`{"ref":"v1.0.0","revision":"master","message":"v1.0.0 release"}`)
 	})
 
-	tag, _, err := testClient.Projects.CreateTag("go", "v1.0.0", input)
+	tag, _, err := testClient.Projects.CreateTag(context.Background(), "go", "v1.0.0", input)
 	if err != nil {
 		t.Errorf("Projects.CreateTag returned error: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestProjectsService_DeleteTag(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.Projects.DeleteTag("go", "v1.0.0")
+	_, err := testClient.Projects.DeleteTag(context.Background(), "go", "v1.0.0")
 	if err != nil {
 		t.Errorf("Projects.DeleteTag returned error: %v", err)
 	}
@@ -87,7 +88,7 @@ func TestProjectsService_DeleteTags(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.Projects.DeleteTags("go", input)
+	_, err := testClient.Projects.DeleteTags(context.Background(), "go", input)
 	if err != nil {
 		t.Errorf("Projects.DeleteTags returned error: %v", err)
 	}

--- a/projects_test.go
+++ b/projects_test.go
@@ -1,6 +1,7 @@
 package gerrit_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -28,7 +29,7 @@ func TestProjectsService_ListProjects(t *testing.T) {
 		Regex: "(arch|benchmarks)",
 	}
 	opt.Limit = 2
-	project, _, err := testClient.Projects.ListProjects(opt)
+	project, _, err := testClient.Projects.ListProjects(context.Background(), opt)
 	if err != nil {
 		t.Errorf("Projects.ListProjects returned error: %v", err)
 	}
@@ -59,7 +60,7 @@ func TestProjectsService_GetProject(t *testing.T) {
 		fmt.Fprint(w, `)]}'`+"\n"+`{"id":"go","name":"go","parent":"All-Projects","description":"The Go Programming Language","state":"ACTIVE"}`)
 	})
 
-	project, _, err := testClient.Projects.GetProject("go")
+	project, _, err := testClient.Projects.GetProject(context.Background(), "go")
 	if err != nil {
 		t.Errorf("Projects.GetProject returned error: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestProjectsService_GetProject_WithSlash(t *testing.T) {
 		c := `)]}'` + "\n" + `{"id":"plugins%2Fdelete-project","name":"plugins/delete-project","parent":"Public-Plugins","description":"A plugin which allows projects to be deleted from Gerrit via an SSH command","state":"ACTIVE"}`
 		fmt.Fprint(w, c)
 	})
-	project, _, err := testClient.Projects.GetProject("plugins/delete-project")
+	project, _, err := testClient.Projects.GetProject(context.Background(), "plugins/delete-project")
 	if err != nil {
 		t.Errorf("Projects.GetProject returned error: %v", err)
 	}
@@ -130,7 +131,7 @@ func TestProjectsService_CreateProject(t *testing.T) {
 		fmt.Fprint(w, `)]}'`+"\n"+`{"id":"go","name":"go","parent":"All-Projects","description":"The Go Programming Language"}`)
 	})
 
-	project, _, err := testClient.Projects.CreateProject("go", input)
+	project, _, err := testClient.Projects.CreateProject(context.Background(), "go", input)
 	if err != nil {
 		t.Errorf("Projects.CreateProject returned error: %v", err)
 	}
@@ -158,7 +159,7 @@ func TestProjectsService_GetProjectDescription(t *testing.T) {
 		fmt.Fprint(w, `)]}'`+"\n"+`"The Go Programming Language"`)
 	})
 
-	description, _, err := testClient.Projects.GetProjectDescription("go")
+	description, _, err := testClient.Projects.GetProjectDescription(context.Background(), "go")
 	if err != nil {
 		t.Errorf("Projects.GetProjectDescription returned error: %v", err)
 	}
@@ -172,7 +173,8 @@ func TestProjectsService_GetProjectDescription(t *testing.T) {
 
 func ExampleProjectsService_ListProjects() {
 	instance := "https://chromium-review.googlesource.com/"
-	client, err := gerrit.NewClient(instance, nil)
+	ctx := context.Background()
+	client, err := gerrit.NewClient(ctx, instance, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -181,7 +183,7 @@ func ExampleProjectsService_ListProjects() {
 		Description: true,
 		Prefix:      "infra/infra/infra_l",
 	}
-	projects, _, err := client.Projects.ListProjects(opt)
+	projects, _, err := client.Projects.ListProjects(ctx, opt)
 	if err != nil {
 		panic(err)
 	}
@@ -255,7 +257,7 @@ func TestProjectsService_GetBranch(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		branchInfo, _, err := testClient.Projects.GetBranch("go", tc.branch)
+		branchInfo, _, err := testClient.Projects.GetBranch(context.Background(), "go", tc.branch)
 		if err != nil {
 			t.Errorf("tc %s: Projects.GetProject returned error: %v", tc.name, err)
 		}


### PR DESCRIPTION
This is a large cross cutting change to the existing interfaces for go-gerrit that introduces context support to all interfaces drilling down to the HTTP level.

Contexts enable support for both passing information through (eg: tracing, logging, etc) and features like cancellation of slow operations (eg: REST calls).

In order for consumers of this breaking change to adapt their code to use the new interface they must add a context parameter to their invocations.  In most cases this can just be `context.Background()`

Fixes #99.