### PR TITLE
Support more options for rebasing changes

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -165,7 +165,12 @@ type ProblemInfo struct {
 
 // RebaseInput entity contains information for changing parent when rebasing.
 type RebaseInput struct {
-	Base string `json:"base,omitempty"`
+	Base               string            `json:"base,omitempty"`
+	Strategy           string            `json:"strategy,omitempty"`
+	AllowConflicts     bool              `json:"allow_conflicts,omitempty"`
+	OnBehalfOfUploader bool              `json:"on_behalf_of_uploader,omitempty"`
+	CommitterEmail     string            `json:"committer_email,omitempty"`
+	ValidationOptions  map[string]string `json:"validation_options,omitempty"`
 }
 
 // RestoreInput entity contains information for restoring a change.


### PR DESCRIPTION
RebaseInput is relatively big at this point; the main field I'm interested in is actually just `on_behalf_of_uploader`, but there are several options missing from go-gerrit

https://gerrit.googlesource.com/gerrit/+/refs/heads/master/java/com/google/gerrit/extensions/api/changes/RebaseInput.java
https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#rebase-input