### PR TITLE
Fix ChangeFileContentInChangeEdit function error

### DIFF
--- a/gerrit.go
+++ b/gerrit.go
@@ -281,6 +281,8 @@ func (c *Client) NewRawPutRequest(ctx context.Context, urlStr string, body strin
 	// See https://gerrit-review.googlesource.com/Documentation/rest-api.html#output
 	// req.Header.Add("Accept", "application/json")
 	// req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Accept", "*/*")
+	req.Header.Add("Content-Type", "text/plain")
 
 	// TODO: Add gzip encoding
 	// Accept-Encoding request header is set to gzip

--- a/gerrit.go
+++ b/gerrit.go
@@ -279,8 +279,8 @@ func (c *Client) NewRawPutRequest(ctx context.Context, urlStr string, body strin
 
 	// Request compact JSON
 	// See https://gerrit-review.googlesource.com/Documentation/rest-api.html#output
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	// req.Header.Add("Accept", "application/json")
+	// req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	// TODO: Add gzip encoding
 	// Accept-Encoding request header is set to gzip


### PR DESCRIPTION
# os:
- Gerrit server version: `3.4.1`

# desc:
When I try to use the `ChangeFileContentInChangeEdit` function to update (or create) file in the remote gerrit server, although no error is reported, the local update content cannot be uploaded to the remote file.
After I used chrome developer tools to manually debug and compare, I found that it was an api **request header** problem:[here](https://github.com/andygrunwald/go-gerrit/blob/6478d3098755d4965bf393b8a50ca8ea819a4d6f/gerrit.go#L282C1-L283C69). After setting the request header to be the same as in chrome:
```golang
req.Header.Add("Accept", "*/*")
req.Header.Add("Content-Type", "text/plain")
```

or delete the `json` setting:
```golang
// req.Header.Add("Accept", "application/json")
// req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
```
 then call this function, the file content can be updated remote server normally.