### PR TITLE
Change ReviewInput to use map[string]int for labels

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -249,7 +249,7 @@ type ReviewerInput struct {
 type ReviewInput struct {
 	Message                          string                         `json:"message,omitempty"`
 	Tag                              string                         `json:"tag,omitempty"`
-	Labels                           map[string]int              `json:"labels,omitempty"`
+	Labels                           map[string]int                 `json:"labels,omitempty"`
 	Comments                         map[string][]CommentInput      `json:"comments,omitempty"`
 	RobotComments                    map[string][]RobotCommentInput `json:"robot_comments,omitempty"`
 	StrictLabels                     bool                           `json:"strict_labels,omitempty"`

--- a/changes.go
+++ b/changes.go
@@ -249,7 +249,7 @@ type ReviewerInput struct {
 type ReviewInput struct {
 	Message                          string                         `json:"message,omitempty"`
 	Tag                              string                         `json:"tag,omitempty"`
-	Labels                           map[string]string              `json:"labels,omitempty"`
+	Labels                           map[string]int              `json:"labels,omitempty"`
 	Comments                         map[string][]CommentInput      `json:"comments,omitempty"`
 	RobotComments                    map[string][]RobotCommentInput `json:"robot_comments,omitempty"`
 	StrictLabels                     bool                           `json:"strict_labels,omitempty"`


### PR DESCRIPTION
The example provided at:

https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-review

uses ints for the label values, not strings.  This change lines ReviewInput up with that example.