### PR TITLE
Add missing fields from ReviewResult

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -202,8 +202,10 @@ type ReviewerUpdateInfo struct {
 // made to a review.
 type ReviewResult struct {
 	ReviewInfo
-	Reviewers map[string]AddReviewerResult `json:"reviewers,omitempty"`
-	Ready     bool                         `json:"ready,omitempty"`
+	Reviewers  map[string]AddReviewerResult `json:"reviewers,omitempty"`
+	Ready      bool                         `json:"ready,omitempty"`
+	Error      string                       `json:"error,omitempty"`
+	ChangeInfo ChangeInfo                   `json:"change_info"`
 }
 
 // TopicInput entity contains information for setting a topic.


### PR DESCRIPTION
ReviewResult has an `error` and `change_info` field that should be captured as well.