### PR TITLE
Fix MoveInput struct definition (keep_all_labels -> keep_all_votes)

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -305,7 +305,7 @@ type CommentInput struct {
 type MoveInput struct {
 	DestinationBranch string `json:"destination_branch"`
 	Message           string `json:"message,omitempty"`
-	KeepAllLabels     bool   `json:"keep_all_labels"`
+	KeepAllVotes      bool   `json:"keep_all_votes"`
 }
 
 // RobotCommentInput entity contains information for creating an inline robot comment.


### PR DESCRIPTION
Since Gerrit 3.4.0, the MoveInput field has been `keep_all_votes` and not `keep_all_labels`. This change makes the MoveInput struct reflect that.