### PR TITLE
Update SubmitInput entity to support new fields

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -226,7 +226,10 @@ type SubmitRecord struct {
 
 // SubmitInput entity contains information for submitting a change.
 type SubmitInput struct {
-	WaitForMerge bool `json:"wait_for_merge"`
+	OnBehalfOf    string                       `json:"on_behalf_of,omitempty"`
+	Notify        string                       `json:"notify,omitempty"`
+	NotifyDetails map[RecipientType]NotifyInfo `json:"notify_details,omitempty"`
+	WaitForMerge  bool                         `json:"wait_for_merge,omitempty"`
 }
 
 // SubmitInfo entity contains information about the change status after submitting.


### PR DESCRIPTION
New fields have been added to SubmitInput to support features such as submitting on behalf of other users, and notification handling. The fields have been all listed as optional to match the current API (as of 3.8+). I'm open to removing  WaitForMerge as well, but that would make this a breaking change.