### PR TITLE
Add new version of ChangeFileContentInChangeEdit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/andygrunwald/go-gerrit
+module github.com/halvfigur/go-gerrit
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/halvfigur/go-gerrit
+module github.com/andygrunwald/go-gerrit
 
 go 1.16
 


### PR DESCRIPTION
Create a variant version of the method that has more strict typing and, unlike the current one, correctly specifies the encoding as json.

It may be that you would rather change the current implementation and make a major version increase, but this seemed a good first step to merge as a PR until then.