### PR TITLE
Add DeleteComment API

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -518,6 +518,13 @@ type MergeInput struct {
 	AllowConflicts bool   `json:"allow_conflicts,omitempty"`
 }
 
+// The DeleteCommentInput entity contains the option for deleting a comment.
+//
+// Docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-comment-input
+type DeleteCommentInput struct {
+	Reason string `json:"reason"`
+}
+
 // The ParentInfo entity contains information about the parent commit of a patch-set.
 type ParentInfo struct {
 	BranchName             string `json:"branch_name,omitempty"`

--- a/changes_revision.go
+++ b/changes_revision.go
@@ -644,6 +644,19 @@ func (s *ChangesService) CherryPickRevision(ctx context.Context, changeID, revis
 	return v, resp, err
 }
 
+// Deletes a published comment of a revision. Instead of deleting the whole comment, this endpoint just replaces the comment’s message with a new message,
+// which contains the name of the user who deletes the comment and the reason why it’s deleted.
+//
+// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-comment
+func (s *ChangesService) DeleteComment(ctx context.Context, changeID, revisionID, commentID string, input *DeleteCommentInput) (*Response, error) {
+	u := fmt.Sprintf("changes/%s/revisions/%s/comments/%s/delete", changeID, revisionID, commentID)
+	req, err := s.client.NewRequest(ctx, "POST", u, input)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
 /*
 TODO: Missing Revision Endpoints
 	Rebase Revision


### PR DESCRIPTION

Add support for the DeleteComment API endpoint that allows deleting published comments on revisions.

## Changes
- Added DeleteCommentInput struct with a Reason field for specifying the deletion reason
- Implemented DeleteComment method on ChangesService to call the Gerrit Delete Comment endpoint

## API Details
- Endpoint: POST /changes/{change-id}/revisions/{revision-id}/comments/{comment-id}/delete
- Behavior: Instead of deleting the whole comment, this endpoint replaces the comment's message with a new message
  containing the name of the user who deletes the comment and the reason why it's deleted

[gerrit-docs](https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-comment)