### PR TITLE
Upgrade supported Go versions from 1.24, 1.25 to 1.25, 1.26

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go: ["1.25", "1.24"]
+        go: ["1.26", "1.25"]
 
     steps:
       - uses: actions/checkout@v7
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go: ["1.25", "1.24"]
+        go: ["1.26", "1.25"]
 
     steps:
       - uses: actions/checkout@v7
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go: ["1.25", "1.24"]
+        go: ["1.26", "1.25"]
 
     steps:
       - uses: actions/checkout@v7
@@ -59,7 +59,7 @@ jobs:
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@v1.4.1
         with:
-          version: "2025.1.1"
+          version: "2026.1"
           install-go: false
           cache-key: ${{ matrix.go }}
 
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go: ["1.25", "1.24"]
+        go: ["1.26", "1.25"]
 
     steps:
       - uses: actions/checkout@v7
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go: ["1.25", "1.24"]
+        go: ["1.26", "1.25"]
 
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go-gerrit is a [Go](https://golang.org/) client library for the [Gerrit Code Rev
 ## Installation
 
 _go-gerrit_ follows the [Go Release Policy](https://golang.org/doc/devel/release.html#policy).
-This means we support the current + 2 previous Go versions.
+This means we support the current + the previous Go version.
 
 It is go gettable ...
 


### PR DESCRIPTION
Go 1.26 is the current upstream release, so per the [Go Release Policy](https://golang.org/doc/devel/release.html#policy) our supported window moves to **1.26 + 1.25**. Until now CI never exercised the version most users are on, while still spending runner time on 1.24, which upstream no longer supports.

## Changes

- **`.github/workflows/testing.yml`** — matrix `["1.25", "1.24"]` → `["1.26", "1.25"]` across all five jobs (`gofmt`, `govet`, `staticcheck`, `golangci-lint`, `unittesting`).
- **`.github/workflows/testing.yml`** — staticcheck `2025.1.1` → `2026.1`. staticcheck only supports the last two Go releases; left at `2025.1.1` it would reject or misparse the new 1.26 matrix entry, so the two bumps have to land together to keep the pipeline green.
- **`README.md`** — the installation section claimed we support "current + 2 previous", which matched neither the two-entry CI matrix nor the release policy it links to. Corrected to state the policy we actually follow.

## Deliberately unchanged

`go.mod` stays at `go 1.16`. What we test against is not the same as the minimum we require from consumers, and raising that floor is a separate, breaking decision.

`release.yml` was already pinned to 1.26, so it needed no edit.

## Verification

- `actionlint` passes on the modified workflow.
- `make vet` and `make test` pass under Go 1.26.5 locally.
- `staticcheck 2026.1` runs clean against the tree under Go 1.26.5 (exit 0, no findings) — this was the job most at risk from the bump.

Real verification is this PR's CI: all 10 job instances (5 jobs × 2 versions) should go green, in particular `staticcheck (Go 1.26)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)