### PR TITLE
Fix golangci-lint 2.12 findings

### DIFF
--- a/events.go
+++ b/events.go
@@ -152,7 +152,7 @@ func (events *EventsLogService) GetEvents(ctx context.Context, options *EventsLo
 	for _, line := range bytes.Split(body, []byte("\n")) {
 		if len(line) > 0 {
 			event := EventInfo{}
-			if err := json.Unmarshal(line, &event); err != nil { // nolint: vetshadow
+			if err := json.Unmarshal(line, &event); err != nil {
 				failures = append(failures, line)
 
 				if !options.IgnoreUnmarshalErrors {

--- a/gerrit.go
+++ b/gerrit.go
@@ -396,7 +396,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 	if v != nil {
 		defer resp.Body.Close() // nolint: errcheck
 		if w, ok := v.(io.Writer); ok {
-			if _, err := io.Copy(w, resp.Body); err != nil { // nolint: vetshadow
+			if _, err := io.Copy(w, resp.Body); err != nil {
 				return nil, err
 			}
 		} else {

--- a/gerrit.go
+++ b/gerrit.go
@@ -540,7 +540,7 @@ var queryParameterReplacements = map[string]string{
 // opt must be a struct whose fields may contain "url" tags.
 func addOptions(s string, opt interface{}) (string, error) {
 	v := reflect.ValueOf(opt)
-	if v.Kind() == reflect.Ptr && v.IsNil() {
+	if v.Kind() == reflect.Pointer && v.IsNil() {
 		return s, nil
 	}
 


### PR DESCRIPTION
Renovate's [golangci-lint 2.11.3 → 2.12.2 bump](https://github.com/andygrunwald/go-gerrit/pull/new/renovate/golangci-golangci-lint-2.x) fails CI:

```
Error: gerrit.go:543:17: inline: Constant reflect.Ptr should be inlined (govet)
level=warning msg="[runner/nolint_filter] Found unknown linters in //nolint directives: vetshadow"
```

Both problems are latent on `master` rather than introduced by that bump — golangci-lint 2.12 simply runs govet's new `inline` analyzer, which 2.11.3 did not. Fixing them here lets the version bump land on its own, without an unrelated code change riding along on a branch Renovate force-pushes.

## Changes

**`reflect.Ptr` → `reflect.Pointer`** (`gerrit.go:543`) — the standard library marks `Ptr` with a `//go:fix inline` directive; `Ptr` is the pre-Go 1.18 name and `Pointer` is its replacement.

`reflect.Pointer` requires Go 1.18 while the module still declares `go 1.16`, so this was checked against govet's `stdversion` analyzer: it does not flag the use. Supported Go versions are 1.25 and 1.26, so no `go.mod` change is needed.

**Removed two stale `// nolint: vetshadow` directives** (`gerrit.go:399`, `events.go:155`) — `vetshadow` was a golangci-lint v1 linter name that no longer exists. Since the v2 migration these have suppressed nothing: shadow checking now lives behind govet's `shadow` analyzer, which is not in the default set and is not enabled in `.golangci.yml`. Dropping them clears the warning without changing which findings are reported.

## Verification

Run locally with golangci-lint 2.12.2 — the exact version the Renovate branch pins.

- Baseline on `master` reproduces both the error and the warning
- After: `golangci-lint run ./...` → `0 issues`, exit 0, no warning
- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass

## Follow-ups (not in this PR)

- The Renovate PR needs a rebase against `master` once this merges
- `go.mod`'s `go 1.16` is stale against the stated support policy (README: current + previous Go; CI tests 1.25 and 1.26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)