### PR TITLE
Fix #224

### DIFF
--- a/gerrit.go
+++ b/gerrit.go
@@ -111,6 +111,19 @@ func NewClient(ctx context.Context, gerritURL string, httpClient *http.Client) (
 		submatch := submatches[0]
 		username = submatch[2]
 		password = submatch[3]
+
+		// The regular expression captures the raw substrings while the
+		// url.Parse() below returns percent decoded credentials. Decode here
+		// too so both code paths agree on the credentials. Values which are
+		// not valid escape sequences are kept as they are because this code
+		// path exists to accept raw credentials that url.Parse() rejects.
+		if decoded, err := url.PathUnescape(username); err == nil {
+			username = decoded
+		}
+		if decoded, err := url.PathUnescape(password); err == nil {
+			password = decoded
+		}
+
 		endpoint = fmt.Sprintf(
 			"%s://%s:%s%s", submatch[1], submatch[4], submatch[5], submatch[6])
 		hasAuth = true

--- a/gerrit_test.go
+++ b/gerrit_test.go
@@ -353,6 +353,101 @@ func TestNewClient_BasicAuth_PasswordWithSlashes(t *testing.T) {
 	}
 }
 
+func TestNewClient_CredentialsInURLAreUnescaped(t *testing.T) {
+	tests := []struct {
+		name     string
+		urlUser  string
+		urlPass  string
+		wantUser string
+		wantPass string
+	}{
+		{
+			name:     "escaped slash in password",
+			urlUser:  "admin",
+			urlPass:  "se%2Fcret",
+			wantUser: "admin",
+			wantPass: "se/cret",
+		},
+		{
+			name:     "escaped at sign in username",
+			urlUser:  "ad%40min",
+			urlPass:  "secret",
+			wantUser: "ad@min",
+			wantPass: "secret",
+		},
+		{
+			name:     "escaped plus in password",
+			urlUser:  "admin",
+			urlPass:  "pa%2Bss",
+			wantUser: "admin",
+			wantPass: "pa+ss",
+		},
+		{
+			name:     "invalid escape sequence is kept as is",
+			urlUser:  "admin",
+			urlPass:  "raw%pass",
+			wantUser: "admin",
+			wantPass: "raw%pass",
+		},
+		{
+			name:     "unescaped password is kept as is",
+			urlUser:  "admin",
+			urlPass:  "ZOSOKjgV/kgEkN0bzPJp+oGeJLqpXykqWFJpon/Ckg",
+			wantUser: "admin",
+			wantPass: "ZOSOKjgV/kgEkN0bzPJp+oGeJLqpXykqWFJpon/Ckg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup()
+			defer teardown()
+
+			account := gerrit.AccountInfo{
+				AccountID: 100000,
+				Name:      "test",
+				Email:     "test@localhost",
+				Username:  "test"}
+			hits := 0
+
+			testMux.HandleFunc("/a/accounts/self", func(w http.ResponseWriter, r *http.Request) {
+				hits++
+				switch hits {
+				case 1:
+					// Digest auth is tried first. Failing it makes the client fall
+					// back to basic auth, where the credentials are readable.
+					writeresponse(t, w, nil, http.StatusUnauthorized)
+				case 2:
+					username, password, ok := r.BasicAuth()
+					if !ok {
+						t.Error("Expected basic auth credentials")
+					}
+					if username != tt.wantUser {
+						t.Errorf("username: %q != %q", tt.wantUser, username)
+					}
+					if password != tt.wantPass {
+						t.Errorf("password: %q != %q", tt.wantPass, password)
+					}
+					writeresponse(t, w, account, http.StatusOK)
+				case 3:
+					t.Error("Did not expect another request")
+				}
+			})
+
+			serverURL := fmt.Sprintf(
+				"http://%s:%s@%s", tt.urlUser, tt.urlPass,
+				testServer.Listener.Addr().String())
+			client, err := gerrit.NewClient(context.Background(), serverURL, nil)
+			if err != nil {
+				t.Error(err)
+			}
+			if !client.Authentication.HasAuth() {
+				t.Error("Expected HasAuth() == true")
+			}
+		})
+	}
+}
+
 func TestNewClient_CookieAuth(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
# Percent-decode URL credentials taken from the ReParseURL match

Fixes #224 

## How this surfaced

While setting up [zoekt](https://github.com/sourcegraph/zoekt) against our
company Gerrit instance (v2.16.28), `zoekt-mirror-gerrit` failed to
authenticate. That Gerrit version generates HTTP passwords that can contain
`/`, and ours did.

`zoekt-mirror-gerrit` does nothing unusual with it:

```go
rootURL.User = url.UserPassword(splitCreds[0], splitCreds[1])
client, err := gerrit.NewClient(ctx, rootURL.String(), newLoggingClient())
```

`/` is not a legal character in the userinfo part of a URL, so `URL.String()`
percent-encodes it. The string that reaches `NewClient` is therefore:

```
https://admin:abc%2Fdef@gerrit.example.com:8080/
```

go-gerrit hands that `%2F` straight to Gerrit, and authentication fails. The
caller did nothing wrong: it built a correct URL with the standard library,
and any caller that assembles credentials through `url.UserPassword` hits the
same wall.

## Root cause

`NewClient` extracts credentials from the URL through two paths that disagree
about encoding.

* The `ReParseURL` path (`gerrit.go`) assigns the regular expression
  submatches directly, so percent escapes are left in place.
* The `url.Parse` path below it reads `url.Userinfo.Username()` and
  `Password()`, which return percent-**decoded** values.

`ReParseURL` requires an explicit port (`:(\d+)`), so which path runs — and
therefore whether credentials get decoded — depends on whether the URL happens
to carry a port:

```
http://admin:se%2Fcret@localhost:8080/        → regex     pass = "se%2Fcret"
http://admin:se%2Fcret@gerrit.example.com/    → url.Parse pass = "se/cret"
```

The still-encoded value is stored as the secret and sent verbatim
(`req.SetBasicAuth` in `addAuthentication`), which is the authentication
failure above.

## The fix

Decode the two submatches so both paths agree:

```go
if decoded, err := url.PathUnescape(username); err == nil {
	username = decoded
}
if decoded, err := url.PathUnescape(password); err == nil {
	password = decoded
}
```

Two details worth calling out, both of which are also in the code comment:

**`PathUnescape`, not `QueryUnescape`.** `QueryUnescape` additionally turns `+`
into a space. That would corrupt the very password quoted in the comment above
`ReParseURL` (`ZOSOKjgV/kgEkN0bzPJp+oGeJLqpXykqWFJpon/Ckg`) and break the
existing `TestNewClient_BasicAuth_PasswordWithSlashes`.

**The decode errors are ignored on purpose.** `PathUnescape` fails on an
unencoded `%`, as in `p%ss`. This code path exists precisely to accept raw
credentials that `url.Parse` rejects, so falling back to the original value
keeps those working rather than turning a working setup into an error.

## Tests

`TestNewClient_ReParseURL` copies the extraction logic into the test body, so
it only ever exercised the regular expression and could not observe what the
client ends up sending. It is left untouched — it is still a valid regression
test for the expression itself.

The new `TestNewClient_CredentialsInURLAreUnescaped` covers the behaviour end
to end, following the existing `TestNewClient_BasicAuth_PasswordWithSlashes`:
the handler fails the digest attempt, the client falls back to basic auth, and
`r.BasicAuth()` reveals the credentials that actually reached the server.

| URL credential | Expected | Why |
| --- | --- | --- |
| `admin` / `se%2Fcret` | `admin` / `se/cret` | the reported case |
| `ad%40min` / `secret` | `ad@min` / `secret` | the username is decoded too |
| `admin` / `pa%2Bss` | `admin` / `pa+ss` | would be a space under `QueryUnescape` |
| `admin` / `raw%pass` | unchanged | invalid escape falls back to the raw value |
| `admin` / `ZOSOKjgV/kgEkN0bzPJp+oGeJLqpXykqWFJpon/Ckg` | unchanged | raw `/` and `+` still work |

The httptest listener address always carries a port, so every case goes
through the `ReParseURL` path — the one that was broken. The `url.Parse` path
is standard library behaviour and is left untested.

Running the test table against the unpatched code fails exactly the three
decoding cases and passes the two "kept as is" cases, which is what the fix is
meant to change and what it is meant to leave alone.

## Compatibility

Credentials without percent escapes are unaffected, since `PathUnescape` is a
no-op on them. Credentials that are not valid escape sequences are unaffected,
because of the error fallback. The one behaviour that changes is the one that
was already broken: a URL with a port whose credentials are percent-encoded.

`url.PathUnescape` has been available since Go 1.8, so the `go 1.16` directive
in `go.mod` is untouched. No dependency changes.

## Verification

All five CI jobs were reproduced locally on Go 1.26.6 and Go 1.25.12:

```
gofmt -d -s .                                  no diff
make vet                                       pass
make test                                      ok
staticcheck 2026.1                             no findings
golangci-lint v2.12.2                          0 issues
```
