### PR TITLE
Raise minimum Go version in go.mod from 1.16 to 1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ first. For more complete details see
 
 ### Unreleased
 
-This version raises the minimum required Go version to Go v1.26.
+This version raises the minimum required Go version to Go 1.26.0.
 
 ### 1.2.0 (2026-08-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ first. For more complete details see
 
 ## Versions
 
+### Unreleased
+
+This version raises the minimum required Go version to Go v1.26.
+
 ### 1.2.0 (2026-08-22)
 
 This version is the last version that supports Go v1.16.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/andygrunwald/go-gerrit
 
-go 1.26
+go 1.26.0
 
 require github.com/google/go-querystring v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/andygrunwald/go-gerrit
 
-go 1.16
+go 1.26
 
 require github.com/google/go-querystring v1.2.0

--- a/projects_test.go
+++ b/projects_test.go
@@ -88,7 +88,7 @@ func TestProjectsService_GetProject_WithSlash(t *testing.T) {
 	setup()
 	defer teardown()
 
-	testMux.HandleFunc("/projects/plugins/delete-project", func(w http.ResponseWriter, r *http.Request) {
+	testMux.HandleFunc("/projects/plugins%2Fdelete-project", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testRequestURL(t, r, "/projects/plugins%2Fdelete-project")
 


### PR DESCRIPTION
## Why

`go.mod` still declared `go 1.16`, which no longer matched the [Go Release Policy](https://go.dev/doc/devel/release#policy)

## How

```sh
go mod edit -go=1.26
go mod tidy
```

## One test had to move with it

At `go 1.26` the new mux matches segment-wise on the *escaped* path, so `TestProjectsService_GetProject_WithSlash` started returning 404: it registered its handler as `/projects/plugins/delete-project` while the client correctly sends `/projects/plugins%2Fdelete-project`. Registering the escaped form routes the request the client actually sends.

This is test-only. The library code is unchanged and correct — it escapes project names per Gerrit convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DnvWmC8vnAyNJL68H6qcu
